### PR TITLE
Evaluate OPAM environment after initialization.

### DIFF
--- a/.travis-opam.sh
+++ b/.travis-opam.sh
@@ -48,6 +48,7 @@ export OPAMYES=1
 # Init opam
 opam init -a
 opam pin add ${pkg} . -n
+eval $(opam config env)
 
 # Install the external dependencies
 depext=`opam list --required-by ${pkg} --rec -e ubuntu -s | tr '\n' ' ' | sed 's/ *$//'`


### PR DESCRIPTION
Required in case any hooks are executed that need OPAM installed binaries (think oasis, menhir, etc.)

Closes #13.
