### PR TITLE
[Tracking] Use containers for faster build

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -1,62 +1,9 @@
 ## basic OCaml and opam installation
 
-full_apt_version () {
-  package=$1
-  version=$2
-  case "${version}" in
-      latest) echo -n "${package}" ;;
-      *) echo -n "${package}="
-         apt-cache show $package \
-             | sed -n "s/^Version: \(${version}\)/\1/p" \
-             | head -1
-  esac
-}
-
 set -uex
-
-# the ocaml version to test
-OCAML_VERSION=${OCAML_VERSION:-latest}
 
 # the base opam repository to use for bootstrapping and catch-all namespace
 BASE_REMOTE=${BASE_REMOTE:-git://github.com/ocaml/opam-repository}
-
-# whether we need a new gcc and binutils
-UPDATE_GCC_BINUTILS=${UPDATE_GCC_BINUTILS:-"0"}
-
-case "$OCAML_VERSION" in
-    3.12) ppa=avsm/ocaml312+opam12 ;;
-    4.00) ppa=avsm/ocaml40+opam12  ;;
-    4.01) ppa=avsm/ocaml41+opam12  ;;
-    4.02) ppa=avsm/ocaml42+opam12  ;;
-    latest) ppa=avsm/ppa-opam-experimental;;
-    *)    echo Unknown compiler version; exit 1;;
-esac
-
-sudo add-apt-repository \
-     "deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe"
-sudo add-apt-repository --yes ppa:${ppa}
-sudo apt-get update -qq
-sudo apt-get install -y \
-     $(full_apt_version ocaml $OCAML_VERSION) \
-     $(full_apt_version ocaml-base $OCAML_VERSION) \
-     $(full_apt_version ocaml-native-compilers $OCAML_VERSION) \
-     $(full_apt_version ocaml-compiler-libs $OCAML_VERSION) \
-     $(full_apt_version ocaml-interp $OCAML_VERSION) \
-     $(full_apt_version ocaml-base-nox $OCAML_VERSION) \
-     $(full_apt_version ocaml-nox $OCAML_VERSION) \
-     $(full_apt_version camlp4 $OCAML_VERSION) \
-     $(full_apt_version camlp4-extra $OCAML_VERSION) \
-     opam
-
-if [ "$UPDATE_GCC_BINUTILS" != "0" ] ; then
-    echo "installing a recent gcc and binutils (mainly to get mirage-entropy-xen working!)"
-    sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-    sudo apt-get -qq update
-    sudo apt-get install -y gcc-4.8
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
-    wget http://mirrors.kernel.org/ubuntu/pool/main/b/binutils/binutils_2.24-5ubuntu3.1_amd64.deb
-    sudo dpkg -i binutils_2.24-5ubuntu3.1_amd64.deb
-fi
 
 ocaml -version
 
@@ -64,7 +11,7 @@ export OPAMYES=1
 
 opam init -a ${BASE_REMOTE}
 eval $(opam config env)
-opam install depext
+#opam install depext
 
 opam --version
 opam --git-version

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -2,6 +2,14 @@
 
 set -uex
 
+wget https://downloads.sourceforge.net/project/zero-install/0install/2.8/0install-linux-x86_64-2.8.tar.bz2
+tar xjf 0install-linux-x86_64-2.8.tar.bz2
+cd 0install-linux-x86_64-2.8
+./install.sh home
+export PATH=$HOME/bin:$PATH
+0install add opam http://tools.ocaml.org/opam.xml
+
+
 # the base opam repository to use for bootstrapping and catch-all namespace
 BASE_REMOTE=${BASE_REMOTE:-git://github.com/ocaml/opam-repository}
 

--- a/travis_opam.ml
+++ b/travis_opam.ml
@@ -61,7 +61,7 @@ let install args =
   begin match extra_deps with
     | None -> ()
     | Some deps ->
-      ?|. "opam depext %s" deps;
+(*       ?|. "opam depext %s" deps; *)
       ?|. "opam install %s" deps
   end;
 
@@ -76,7 +76,7 @@ let install args =
   end
 
 let install_with_depopts args depopts =
-  ?|~ "opam depext %s" depopts;
+(*   ?|~ "opam depext %s" depopts; *)
   ?|~ "opam install %s" depopts;
   install args;
   ?|~ "opam remove %s -v" pkg;
@@ -108,7 +108,7 @@ List.iter pin pins;
 ?|  "eval $(opam config env)";
 
 (* Install the external dependencies *)
-?|~ "opam depext %s" pkg;
+(* ?|~ "opam depext %s" pkg; *)
 
 (* Install the OCaml dependencies *)
 ?|~ "opam install %s --deps-only" pkg;
@@ -171,7 +171,7 @@ match revdeps with
 
   ignore (List.fold_left (fun i dependent ->
     echo "\nInstalling %s (REVDEP %d/%d)" dependent i installable_count;
-    ?|~ "opam depext %s" dependent;
+(*     ?|~ "opam depext %s" dependent; *)
     ?|~ "opam install %s" dependent;
     ?|~ "opam remove %s" dependent;
     i + 1


### PR DESCRIPTION
This PR removes all use of sudo, allowing projects to build using the faster EC2 instances (in particular, these start much faster).

It gets ocaml from the `avsm` PPA (which is whitelisted), but gets opam from 0install because `aspcud` isn't whitelisted and opam gives bad results without it.

Sample `.travis.yml` using this:

```
language: c
install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
script: bash -ex .travis-opam.sh
sudo: false
addons:
  apt:
    sources:
    - avsm
    packages:
    - ocaml
    - ocaml-base
    - ocaml-native-compilers
    - ocaml-compiler-libs
    - ocaml-interp
    - ocaml-base-nox
    - ocaml-nox
    - camlp4
    - camlp4-extra
    - libgmp-dev
    - libpcre3-dev
    - libssl-dev
    - m4
    - pkg-config
    - time
    - zlib1g-dev
    - libcurl3
    - bzip2
    - curl
    - patch
env:
  - FORK_USER=talex5 FORK_BRANCH=containers
```

It would be easy to allow selecting a different version of opam here (just pass e.g. `--version=1.2.0` to the `0install add` command), but changing the version of ocaml will require adding a constraint to the `.travis.yml` somehow (untested).