### PR TITLE
mirage: check in the skeleton config files to deployment

### DIFF
--- a/travis_mirage.ml
+++ b/travis_mirage.ml
@@ -96,7 +96,7 @@ then begin
   (* remove and recreate any existing image for this commit *)
   ?|  "rm -rf $DEPLOYD/xen/$TRAVIS_COMMIT";
   ?|  "mkdir -p $DEPLOYD/xen/$TRAVIS_COMMIT";
-  ?|  "cp $MIRDIR/$XENIMG $MIRDIR/config.ml $DEPLOYD/xen/$TRAVIS_COMMIT";
+  ?|  "cp $MIRDIR/$XENIMG $MIRDIR/config.ml $MIRDIR/*.xl.in $MIRDIR/*.xe $DEPLOYD/xen/$TRAVIS_COMMIT";
   ?|  "bzip2 -9 $DEPLOYD/xen/$TRAVIS_COMMIT/$XENIMG";
   ?|  "echo $TRAVIS_COMMIT > $DEPLOYD/xen/latest";
   (* commit and push changes *)


### PR DESCRIPTION
The skeleton config files look like this:
```
    # Generated by Mirage (Tue, 10 Nov 2015 18:39:22 GMT).

    name = '@NAME@'
    kernel = '@KERNEL@'
    builder = 'linux'
    memory = @MEMORY@
    on_crash = 'preserve'

    disk = [ 'format=raw, vdev=xvdb, access=rw, target=@BLOCK:xvda1@' ]

    # if your system uses openvswitch then either edit /etc/xen/xl.conf and set
    #     vif.default.script="vif-openvswitch"
    # or add "script=vif-openvswitch," before the "bridge=" below:
    vif = [ 'bridge=@NETWORK:net_tap0@' ]
```
They contain the hardware configuration needed by the VM with physical
resources (disks, network interfaces etc) represented as substitutable
@VARIABLES@. A deployment script can take a skeleton config file,
specialise it and then start the VM. This avoids there being a mismatch
between (for example) the slot number on the bus of the disk expected
by the VM, versus what the host provides ("xvda" vs "xvdb")

Signed-off-by: David Scott <dave.scott@unikernel.com>