### PR TITLE
Better detection of opam files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=3.12
   - OCAML_VERSION=4.00
   - OCAML_VERSION=4.01
   - OCAML_VERSION=4.02

--- a/travis_opam.ml
+++ b/travis_opam.ml
@@ -115,8 +115,20 @@ begin (* remotes *)
   List.iter add_remote extra_remotes
 end;
 
+let (/) = Filename.concat in
+
+let opam =
+  if Sys.file_exists (pkg ^ ".opam") then (pkg ^ ".opam")
+  else if Sys.file_exists "opam"
+       && Sys.is_directory "opam"
+       && Sys.file_exists ("opam" / "opam")
+  then ("opam" / "opam")
+  else if Sys.file_exists "opam" then "opam"
+  else failwith "No opam file found, aborting."
+in
+
 List.iter pin pins;
-?|~ "if [ -d opam ]; then opam lint opam; else opam lint; fi";
+?|~ "opam lint %s" opam;
 ?|~ "opam pin add %s . -n" pkg;
 ?|  "eval $(opam config env)";
 ?|  "opam install depext";


### PR DESCRIPTION
Some repo can contain multiple opam files (e.g. mirage/mirage contains
mirage and mirage-types), so we need to look for `<pkg>.opam`

Fix https://github.com/mirage/mirage/issues/496