### PR TITLE
appveyor: initialize the environment properly

### DIFF
--- a/appveyor-opam.sh
+++ b/appveyor-opam.sh
@@ -1,13 +1,46 @@
 #!/usr/bin/env sh
 
+# default setttings
+SWITCH='4.02.3+mingw64c'
+OPAM_URL='https://dl.dropboxusercontent.com/s/b2q2vjau7if1c1b/opam64.tar.xz'
+OPAM_ARCH=opam64
+
+if [ "$PROCESSOR_ARCHITECTURE" != "AMD64" ] && \
+       [ "$PROCESSOR_ARCHITEW6432" != "AMD64" ]; then
+    OPAM_URL='https://dl.dropboxusercontent.com/s/eo4igttab8ipyle/opam32.tar.xz'
+    OPAM_ARCH=opam32
+fi
+
+if [ $# -gt 0 ] && [ -n "$1" ]; then
+    SWITCH=$1
+fi
+
+export CYGWIN='winsymlinks:native'
 export OPAMYES=1
 
-curl -fsSL -o opam64.tar.xz "https://dl.dropboxusercontent.com/s/b2q2vjau7if1c1b/opam64.tar.xz"
-tar -xf opam64.tar.xz
-opam64/install.sh
-opam init -a mingw "https://github.com/fdopen/opam-repository-mingw.git" --comp 4.02.3+mingw64c --switch 4.02.3+mingw64c
-opam install depext-cygwinports depext
+set -eu
 
+curl -fsSL -o "${OPAM_ARCH}.tar.xz" "${OPAM_URL}"
+tar -xf "${OPAM_ARCH}.tar.xz"
+"${OPAM_ARCH}/install.sh"
+
+opam init -a mingw "https://github.com/fdopen/opam-repository-mingw.git" --comp "$SWITCH" --switch "$SWITCH"
+eval $(opam config env)
+ocaml_system="$(ocamlc -config | awk '/^system:/ { print $2 }')"
+case "$ocaml_system" in
+    *mingw64*)
+        PATH="/usr/x86_64-w64-mingw32/sys-root/mingw/bin:${PATH}"
+        export PATH
+        ;;
+    *mingw*)
+        PATH="/usr/i686-w64-mingw32/sys-root/mingw/bin:${PATH}"
+        export PATH
+        ;;
+    *)
+        echo "ocamlc reports a dubious system: ${ocaml_system}. Good luck!" >&2
+esac
+opam install depext-cygwinports depext
+eval $(opam config env)
 opam pin add my-pkg "${APPVEYOR_BUILD_FOLDER}" -n -k path
 opam depext  my-pkg
 opam install my-pkg


### PR DESCRIPTION
RE: https://github.com/fdopen/opam-repository-mingw/issues/12#issuecomment-191918017

- it should now work for all windows versions (32-bit and 64-bit)
- the environment is properly updated after `opam init`
- if possible, native symlinks are used for better compatibility with unix scripts (see e.g. https://github.com/mirage/ocaml-cstruct/issues/83 )
- you can now optionally pass a switch to the script (eg. `4.01.0+mingw32c` or `4.03.0+beta1+mingw64`) to select the compiler that should be installed.