### PR TITLE
mirage: check in any generated .xl.in file

### DIFF
--- a/travis_mirage.ml
+++ b/travis_mirage.ml
@@ -97,7 +97,7 @@ then begin
   (* remove and recreate any existing image for this commit *)
   ?|  "rm -rf $DEPLOYD/xen/$TRAVIS_COMMIT";
   ?|  "mkdir -p $DEPLOYD/xen/$TRAVIS_COMMIT";
-  ?|  "cp $MIRDIR/$XENIMG $MIRDIR/config.ml $DEPLOYD/xen/$TRAVIS_COMMIT";
+  ?|  "cp $MIRDIR/$XENIMG $MIRDIR/config.ml $MIRDIR/*.xl.in $DEPLOYD/xen/$TRAVIS_COMMIT";
   ?|  "bzip2 -9 $DEPLOYD/xen/$TRAVIS_COMMIT/$XENIMG";
   ?|  "echo $TRAVIS_COMMIT > $DEPLOYD/xen/latest";
   (* commit and push changes *)


### PR DESCRIPTION
mirage 2.7.0 will generate an .xl.in file as part of the configure
phase. This file contains the virtual hardware configuration needed
by the kernel, with holes where the network bridges, disk images
and memory settings should go.

This patch ensures that any generated .xl.in file is checked into
the binary repo alongside the kernel that it describes.

Deployment scripts should use the .xl.in files as a template, so there
is no unexpected breakage if (for example) the virtual disk device
changes from xvda to xvdb, or if the VM is booted HVM rather than PV.

This is part of [mirage/mirage#443]

Signed-off-by: David Scott <dave.scott@docker.com>