### PR TITLE
Removal demands should be baseless

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -1,6 +1,12 @@
 #!/bin/sh -e
 # To use this, run `opam travis --help`
 
+default_user=ocaml
+default_branch=master
+
+fork_user=${FORK_USER:-$default_user}
+fork_branch=${FORK_BRANCH:-$default_branch}
+
 echo -en 'travis_fold:start:script.1\\r'
 # create env file
 echo PACKAGE="$PACKAGE" > env.list
@@ -18,6 +24,13 @@ echo POST_INSTALL_HOOK="$POST_INSTALL_HOOK" >> env.list
 echo FROM ocaml/opam:${DISTRO}_ocaml-${OCAML_VERSION} > Dockerfile
 echo WORKDIR /home/opam/opam-repository >> Dockerfile
 echo RUN git pull origin master >> Dockerfile
+
+if [ $fork_user != $default_user -o $fork_branch != $default_branch ]; then
+    echo RUN opam pin add travis-opam \
+         https://github.com/$fork_user/ocaml-ci-scripts.git#$fork_branch \
+         >> Dockerfile
+fi
+
 echo RUN opam update -u -y >> Dockerfile
 echo VOLUME /repo >> Dockerfile
 echo WORKDIR /repo >> Dockerfile

--- a/.travis-mirage.sh
+++ b/.travis-mirage.sh
@@ -9,7 +9,7 @@ fork_branch=${FORK_BRANCH:-master}
 set -uex
 
 get() {
-  wget https://raw.githubusercontent.com/${fork_user}/ocaml-travisci-skeleton/${fork_branch}/$@
+  wget https://raw.githubusercontent.com/${fork_user}/ocaml-ci-scripts/${fork_branch}/$@
 }
 
 TMP_BUILD=$(mktemp -d)

--- a/.travis-opam.sh
+++ b/.travis-opam.sh
@@ -9,7 +9,7 @@ fork_branch=${FORK_BRANCH:-master}
 set -uex
 
 get() {
-  wget https://raw.githubusercontent.com/${fork_user}/ocaml-travisci-skeleton/${fork_branch}/$@
+  wget https://raw.githubusercontent.com/${fork_user}/ocaml-ci-scripts/${fork_branch}/$@
 }
 
 TMP_BUILD=$(mktemp -d 2>/dev/null || mktemp -d -t 'travistmpdir')

--- a/travis_opam.ml
+++ b/travis_opam.ml
@@ -57,6 +57,15 @@ let pin pin = match pair pin with
   | (pkg,None)     -> ?|. "opam pin add %s --dev-repo -n" pkg
   | (pkg,Some url) -> ?|. "opam pin add %s %s -n" pkg url
 
+let is_base pkg =
+  match trim (?|> "opam show -f version %s" pkg) with
+  | "base" -> true
+  | _ -> false
+
+let filter_base pkgs =
+  let baseless = List.filter (fun pkg -> not (is_base pkg)) (list pkgs) in
+  baseless *~ " "
+
 let install args =
   begin match extra_deps with
     | None -> ()
@@ -72,7 +81,7 @@ let install args =
   begin match extra_deps with
     | None -> ()
     | Some deps ->
-      ?|. "opam remove %s" deps
+      ?|. "opam remove %s" (filter_base deps)
   end
 
 let install_with_depopts depopts =
@@ -80,7 +89,7 @@ let install_with_depopts depopts =
   ?|~ "opam install %s" depopts;
   install ["-v"];
   ?|~ "opam remove %s -v" pkg;
-  ?|~ "opam remove %s" depopts
+  ?|~ "opam remove %s" (filter_base depopts)
 
 let max_version package =
   let rec next_version last =


### PR DESCRIPTION
Removal of `base-*` packages (as determined by having a version `base`) should not be attempted.

This patchset filters out packages that have a version of `base` from the packages to be removed. This fixes #93.

Also, `FORK_USER` and `FORK_BRANCH` field support was added to the `.travis-docker.sh` file to make it easier to experiment with modifications to this tool.

Also, mentions of `ocaml-travisci-skeleton` were updated to `ocaml-ci-scripts`.