### PR TITLE
Prepare for 1.0.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+1.0.3 (trunk):
+* Don't attempt to remove base-* packages which will always fail (#93)
+
 1.0.2 (2016-03-01):
 * Docker: Update package metadata before installing depexts (#80)
 * Docker: Refresh origin OPAM repository to latest master upon build (#79)


### PR DESCRIPTION
@avsm @samoht it would be nice to get #96 into the Docker images by releasing 1.0.3 in opam-repository and doing whatever is necessary to refresh the container images.