### PR TITLE
trusty now comes with binutils 2.24

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -72,8 +72,6 @@ install_on_linux () {
     sudo apt-get -qq update
     sudo apt-get install -y gcc-4.8
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
-    wget http://mirrors.kernel.org/ubuntu/pool/main/b/binutils/binutils_2.24-5ubuntu3.1_amd64.deb
-    sudo dpkg -i binutils_2.24-5ubuntu3.1_amd64.deb
     sudo add-apt-repository -r "${TRUSTY}"
   fi
 


### PR DESCRIPTION
..which can be seen e.g. in https://travis-ci.org/mirage/mirage-entropy/jobs/128767313

```
+echo installing a recent gcc and binutils (mainly to get mirage-entropy-xen working!)
installing a recent gcc and binutils (mainly to get mirage-entropy-xen working!)
+sudo add-apt-repository deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe
+sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
...
+sudo apt-get -qq update
+sudo apt-get install -y gcc-4.8
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following extra packages will be installed:
  binutils cpp-4.8 gcc-4.8-base gcc-5-base libasan0 libatomic1 libcloog-isl4
  libgcc-4.8-dev libgcc1 libgomp1 libisl10 libitm1 libmpc3 libmpfr4
  libquadmath0 libtsan0
...
Get:6 http://mirror.stjschools.org/public/ubuntu-archive/ trusty/main binutils amd64 2.24-5ubuntu3 [2,071 kB]
...
Preparing to replace binutils 2.22-6ubuntu1.3 (using .../binutils_2.24-5ubuntu3_amd64.deb) ...
...
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
update-alternatives: using /usr/bin/gcc-4.8 to provide /usr/bin/gcc (gcc) in auto mode.
```

and then our (now superfluous) wget of binutils 2.24
```
+wget http://mirrors.kernel.org/ubuntu/pool/main/b/binutils/binutils_2.24-5ubuntu3.1_amd64.deb
--2016-05-09 05:26:19--  http://mirrors.kernel.org/ubuntu/pool/main/b/binutils/binutils_2.24-5ubuntu3.1_amd64.deb
Resolving mirrors.kernel.org (mirrors.kernel.org)... 198.145.20.143, 149.20.37.36, 2620:3:c000:a:0:1994:3:14, ...
Connecting to mirrors.kernel.org (mirrors.kernel.org)|198.145.20.143|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2076298 (2.0M) [application/octet-stream]
Saving to: `binutils_2.24-5ubuntu3.1_amd64.deb'
100%[======================================>] 2,076,298   6.74M/s   in 0.3s    
2016-05-09 05:26:19 (6.74 MB/s) - `binutils_2.24-5ubuntu3.1_amd64.deb' saved [2076298/2076298]
+sudo dpkg -i binutils_2.24-5ubuntu3.1_amd64.deb
(Reading database ... 126277 files and directories currently installed.)
Preparing to replace binutils 2.24-5ubuntu3 (using binutils_2.24-5ubuntu3.1_amd64.deb) ...
Unpacking replacement binutils ...
Setting up binutils (2.24-5ubuntu3.1) ...
Processing triggers for man-db ...
Processing triggers for libc-bin ...
ldconfig deferred processing now taking place
```