### PR TITLE
On OS X, install 4.03 if the user asks for 4.03

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -101,7 +101,7 @@ install_on_osx () {
     4.01,1.2.2) OPAM_SWITCH=4.01.0; brew install opam ;;
     4.02,1.2.2) OPAM_SWITCH=4.02.3; brew install opam ;;
     4.02,1.3.0) OPAM_SWITCH=4.02.3; brew install opam --HEAD ;;
-    4.03,1.2.2) brew install ocaml --HEAD; brew install opam ;;
+    4.03,1.2.2) OPAM_SWITCH=4.03.0; brew install opam ;;
     *) echo "Unknown OCAML_VERSION=$OCAML_VERSION OPAM_VERSION=$OPAM_VERSION"
        exit 1 ;;
   esac


### PR DESCRIPTION
Before, we installed from SVN trunk instead.

(and trunk currently fails with:
```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/ocamlbuild
Target /usr/local/bin/ocamlbuild
is a symlink belonging to ocaml. You can unlink it:
  brew unlink ocaml
```
)