### PR TITLE
Remove trailing spaces from .travis-ocaml.sh

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -40,13 +40,13 @@ install_on_linux () {
   case "$OCAML_VERSION,$OPAM_VERSION" in
     3.12,1.2.2)
        OCAML_VERSION=4.02; OPAM_SWITCH="3.12.1"
-       ppa=avsm/ocaml42+opam12 ;; 
+       ppa=avsm/ocaml42+opam12 ;;
     4.00,1.2.2)
        OCAML_VERSION=4.02; OPAM_SWITCH="4.00.1"
-       ppa=avsm/ocaml42+opam12 ;; 
+       ppa=avsm/ocaml42+opam12 ;;
     4.01,1.2.2)
        OCAML_VERSION=4.02; OPAM_SWITCH="4.01.0"
-       ppa=avsm/ocaml42+opam12 ;;       
+       ppa=avsm/ocaml42+opam12 ;;
     4.02,1.1.2) OPAM_SWITCH=4.02.3; ppa=avsm/ocaml42+opam11 ;;
     4.02,1.2.0) OPAM_SWITCH=4.02.3; ppa=avsm/ocaml42+opam120 ;;
     4.02,1.2.1) OPAM_SWITCH=4.02.3; ppa=avsm/ocaml42+opam121 ;;


### PR DESCRIPTION
Remove trailing spaces from `.travis-ocaml.sh` introduced by 05fd56af6bd2ee13ef53a642cb3e65e174982cb6.