### PR TITLE
Remove bzip2 target before invoking bzip2

### DIFF
--- a/travis_mirage.ml
+++ b/travis_mirage.ml
@@ -101,10 +101,10 @@ then begin
   ?|  "echo $TRAVIS_COMMIT > $DEPLOYD/xen/latest";
   (* commit and push changes *)
   ?|  "cd $DEPLOYD &&\
-       \ git add xen/$TRAVIS_COMMIT xen/latest &&\
-       \ git commit -m \"adding $TRAVIS_COMMIT for $MIRAGE_BACKEND\" &&\
-       \ git status &&\
-       \ git clean -fdx &&\
-       \ git pull --rebase &&\
-       \ git push"
+      \ git add xen/$TRAVIS_COMMIT xen/latest &&\
+      \ git commit -m \"adding $TRAVIS_COMMIT for $MIRAGE_BACKEND\" &&\
+      \ git status &&\
+      \ git clean -fdx &&\
+      \ git pull --rebase &&\
+      \ git push"
 end

--- a/travis_mirage.ml
+++ b/travis_mirage.ml
@@ -97,6 +97,7 @@ then begin
   (* remove and recreate any existing image for this commit *)
   ?|  "mkdir -p $DEPLOYD/xen/$TRAVIS_COMMIT";
   ?|  "cp $MIRDIR/$XENIMG $MIRDIR/config.ml $DEPLOYD/xen/$TRAVIS_COMMIT";
+  ?|  "rm -f $DEPLOYD/xen/$TRAVIS_COMMIT/${XENIMG}.bz2";
   ?|  "bzip2 -9 $DEPLOYD/xen/$TRAVIS_COMMIT/$XENIMG";
   ?|  "echo $TRAVIS_COMMIT > $DEPLOYD/xen/latest";
   (* commit and push changes *)


### PR DESCRIPTION
Recently noticed that forcing Travis to redo a deployment build when (e.g.,) upstream libraries have been updated or a `PIN` is introduced didn't seem to trigger a redployment: the invocation of `bzip2` failed because the target file already existed in the deployment repo.

This PR allows that case to succeed by first removing the target of the `bzip2` invocation.