### PR TITLE
Allow to set OPAM_SWITCH on appveyor

### DIFF
--- a/appveyor-opam.sh
+++ b/appveyor-opam.sh
@@ -7,7 +7,7 @@ fork_user=${FORK_USER:-ocaml}
 fork_branch=${FORK_BRANCH:-master}
 
 # default setttings
-SWITCH='4.02.3+mingw64c'
+SWITCH=${OPAM_SWITCH:-'4.02.3+mingw64c'}
 OPAM_URL='https://dl.dropboxusercontent.com/s/b2q2vjau7if1c1b/opam64.tar.xz'
 OPAM_ARCH=opam64
 


### PR DESCRIPTION
@fdopen do you use what you've added to line 20/23?
```
if [ $# -gt 0 ] && [ -n "$1" ]; then
     SWITCH=$1
 fi
```

 I think it is best to use `OPAM_SWITCH` here to be consistent with TravisCI scripts. If you don't use it, do you mind if I remove these lines?