### PR TITLE
added travis-like runner as a docker container

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -37,8 +37,16 @@ echo WORKDIR /repo >> Dockerfile
 docker build -t local-build .
 echo -en 'travis_fold:end:script.1\\r'
 
-# run travis-opam with the local repo volume mounted
+echo -n 'travis_fold:start:dockerfile\\r'
+echo Dockerfile:
+cat Dockerfile
+echo env.list:
+cat env.list
+echo Command:
 OS=~/build/$TRAVIS_REPO_SLUG
+echo docker run --env-file=env.list -v ${OS}:/repo local-build travis-opam
+echo -n 'travis_fold:end:dockerfile\\r'
+
+# run travis-opam with the local repo volume mounted
 chmod -R a+w $OS
 docker run --env-file=env.list -v ${OS}:/repo local-build travis-opam
-

--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -7,7 +7,6 @@ default_branch=master
 fork_user=${FORK_USER:-$default_user}
 fork_branch=${FORK_BRANCH:-$default_branch}
 
-echo -en 'travis_fold:start:script.1\\r'
 # create env file
 echo PACKAGE="$PACKAGE" > env.list
 echo EXTRA_REMOTES="$EXTRA_REMOTES" >> env.list
@@ -35,9 +34,7 @@ echo RUN opam update -u -y >> Dockerfile
 echo VOLUME /repo >> Dockerfile
 echo WORKDIR /repo >> Dockerfile
 docker build -t local-build .
-echo -en 'travis_fold:end:script.1\\r'
 
-echo -n 'travis_fold:start:dockerfile\\r'
 echo Dockerfile:
 cat Dockerfile
 echo env.list:
@@ -45,8 +42,7 @@ cat env.list
 echo Command:
 OS=~/build/$TRAVIS_REPO_SLUG
 echo docker run --env-file=env.list -v ${OS}:/repo local-build travis-opam
-echo -n 'travis_fold:end:dockerfile\\r'
 
-# run travis-opam with the local repo volume mounted
+# run ci-opam with the local repo volume mounted
 chmod -R a+w $OS
-docker run --env-file=env.list -v ${OS}:/repo local-build travis-opam
+docker run --env-file=env.list -v ${OS}:/repo local-build ci-opam

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
-1.0.3 (trunk):
+1.0.3 (2016-11-23):
+* Always run `depext -u` to update the base OS (#138)
 * Don't attempt to remove base-* packages which will always fail (#93)
 * Complete the Appveyor CI scripts to be on-par with those for Travis CI (#101)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:14.04.5
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    m4 \
+    make \
+    python-software-properties \
+    software-properties-common \
+    sudo \
+    wget \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -c "Travis runner" -d /build-script -m travis
+RUN echo 'travis ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/99-travis-user
+
+VOLUME ["/build"]
+
+ADD travis-runner.sh /build-script/travis-runner.sh
+
+CMD ["/build-script/travis-runner.sh"]

--- a/README-travis-runner.md
+++ b/README-travis-runner.md
@@ -1,0 +1,12 @@
+Simple container to reproduce travis builds for opam packages. Something like this should work from the package's project root:
+
+```
+docker run \
+  -v ${PWD}:/build \
+  -e PACKAGE=<package-name> \
+  -e OCAML_VERSION=4.03 \
+  -e EXTRA_REMOTES=<remote-url>
+  -ti fgimenez/ocaml-travis-runner
+```
+
+You can add `bash` at the end of the command to open a shell on the container and execute individual steps manually (the runner script is at `/build-script/travis-runner.sh`).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
+  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/ci_opam.ml
+++ b/ci_opam.ml
@@ -162,7 +162,7 @@ end;
 begin (* tests *)
   if tests_run then
     with_opambuildtest (fun () ->
-        ?|~ "opam depext %s" pkg;
+        ?|~ "opam depext -u %s" pkg;
         ?|~ "opam install %s --deps-only" pkg;
         install ["-v";"-t"];
         ?|~ "opam remove %s -v" pkg)
@@ -215,7 +215,7 @@ begin (* reverse dependencies *)
 
     ignore (List.fold_left (fun i dependent ->
         echo "\nInstalling %s (REVDEP %d/%d)" dependent i installable_count;
-        ?|~ "opam depext %s" dependent;
+        ?|~ "opam depext -u %s" dependent;
         ?|~ "opam install %s" dependent;
         ?|~ "opam remove %s" dependent;
         i + 1

--- a/travis-runner.sh
+++ b/travis-runner.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd /build || exit
+wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+trap 'rm .travis-opam.sh' EXIT
+
+su -l -c "cd /build && \
+    TRAVIS_OS_NAME=linux \
+    OCAML_VERSION=$OCAML_VERSION \
+    PACKAGE=$PACKAGE \
+    EXTRA_REMOTES=$EXTRA_REMOTES \
+    bash -ex .travis-opam.sh" travis


### PR DESCRIPTION
Simple container to execute package builds on a clean environment similar to travis'. It is meant to be used from the root of the package's source dir like:
```
docker run \
  -v ${PWD}:/build \
  -e PACKAGE=<package-name> \
  -e OCAML_VERSION=4.03 \
  -e EXTRA_REMOTES=<remote-urls>
  -ti fgimenez/ocaml-travis-runner
```

This command (and the description in the readme), refer to the `fgimenez/ocaml-travis-runner` docker image (automated build in dockerhub poiting to https://github.com/fgimenez/ocaml-travis-runner), if this PR gets merged it should be updated to the final image built from this repo.