### PR TITLE
containerized travis runner

### DIFF
--- a/README-travis-runner.md
+++ b/README-travis-runner.md
@@ -1,0 +1,20 @@
+Simple containerized environment to reproduce travis builds for opam packages using the [.travis-docker.sh script](https://github.com/ocaml/ocaml-ci-scripts/blob/master/.travis-docker.sh). It creates a "docker in docker" server instance and a docker client that talks to it and acts as the travis runner, creating the container in which the build is executed. The docker server container uses a persistent host volume in `${HOME}/.dind-storage` to speed up the builds (images are kept in the host and only need to be downloaded once).
+
+As a first step you need to create a file with all the required environment variables:
+
+```
+$ cat <<EOF >> env.sh
+export DISTRO=ubuntu-16.04
+export OCAML_VERSION=4.04.0
+export PACKAGE=ocaml-uri
+
+export POST_INSTALL_HOOK="OPAMYES=true opam depext -i react ssl lwt"
+export REVDEPS="cohttp git github irmin sociaml-facebook-api sociaml-oauth-client sociaml-tumblr-api spotify-web-api syndic"
+...
+```
+At least `DISTRO`, `OCAML_VERSION` and `PACKAGE` are required. Then, from the target project root you can execute the `run.sh` script in this repo passing the previously created `env.sh` file path as parameter:
+
+```
+/path/to/ocaml-ci-scripts/travis-runner/run.sh /path/to/env.sh
+
+```

--- a/travis-runner/Dockerfile
+++ b/travis-runner/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker:1.7
+
+RUN apk update && apk add bash wget git
+
+RUN adduser -S travis
+RUN echo 'travis ALL=(ALL) ALL' >> /etc/sudoers
+RUN mkdir -p /root/build/orig && chmod a+w /root/build/orig
+
+ADD travis-runner.sh /build-script/travis-runner.sh
+
+CMD ["/build-script/travis-runner.sh"]

--- a/travis-runner/run.sh
+++ b/travis-runner/run.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -ex
+
+ENV_FILE=$1
+
+if [ -z "$ENV_FILE" ]; then
+    echo "No env file passed as argument"
+    exit 1
+fi
+
+DIND_STORAGE=${HOME}/.dind-storage
+mkdir -p "$DIND_STORAGE"
+
+tmp=$(mktemp -d)
+docker run --privileged \
+       -v $tmp:/root/build/repo \
+       -v $DIND_STORAGE:/var/lib/docker \
+       --name ocaml-docker \
+       -d docker:dind \
+       --storage-driver=aufs
+trap 'docker rm --force ocaml-docker; rm -rf $tmp' EXIT
+docker run \
+       -v ${PWD}:/root/build/orig \
+       -v ${ENV_FILE}:/build-script/env.sh \
+       -v $tmp:/root/build/repo \
+       --rm --link ocaml-docker:docker \
+       fgimenez/ocaml-travis-runner

--- a/travis-runner/travis-runner.sh
+++ b/travis-runner/travis-runner.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+SCRIPT=".travis-docker.sh"
+wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/${SCRIPT} -O /build-script/${SCRIPT}
+
+. /build-script/env.sh
+
+cp -ar /root/build/orig/. /root/build/repo
+cd /root/build/repo || exit
+git ls-files . --others | xargs rm -rf
+
+TRAVIS_OS_NAME=linux \
+    TRAVIS_REPO_SLUG=repo \
+    bash -ex /build-script/${SCRIPT}


### PR DESCRIPTION
These changes add the means to be able to execute builds locally using https://github.com/ocaml/ocaml-ci-scripts/blob/master/.travis-docker.sh which is currently being used for Travis builds. 

The README has the details, but basically it sets up a "docker in docker" server and a client, in which the container required by the build is created and the build is executed.

Thanks!