### PR TITLE
Run depopts tests

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,4 @@
 PKG unix
 SRC .
 B _build
+FLG -w A

--- a/ci_opam.ml
+++ b/ci_opam.ml
@@ -85,7 +85,7 @@ let install args =
   if tests_run then
     let deps = with_opambuildtest (fun () ->
         ?|~ "opam depext -u %s" pkg;
-        ?|>  "opam list --short --required-by %s" pkg |> lines
+        ?|>  "opam list --short --recursive --required-by %s" pkg |> lines
       ) in
     (* 'opam install --deps-only' would run the tests too,
      * which we don't want.
@@ -107,7 +107,7 @@ let install args =
 let install_with_depopts depopts =
   ?|~ "opam depext -u %s" depopts;
   ?|~ "opam install %s" depopts;
-  install ["-v"];
+  install ("-v" :: if tests_run then ["-t"] else []);
   ?|~ "opam remove %s -v" pkg;
   ?|~ "opam remove %s" (filter_base depopts)
 

--- a/ci_opam.ml
+++ b/ci_opam.ml
@@ -82,7 +82,8 @@ let install ?(depopts="") ?(tests=false) args =
        * Even if we'd run it without OPAMBUILDTEST the test-only
        * dependencies would still run their tests during installataion *)
       let deps = with_opambuildtest (fun () ->
-          ?|> "opam list --short --recursive --required-by %s" pkg |> lines
+          let output = ?|> "opam list --short --recursive --required-by %s" pkg in
+          lines output
         ) in
       (extra_deps :: depopts :: ql deps) *~ " "
     else extra_deps in


### PR DESCRIPTION
This tries to reduce the amount of tests run when doing 'opam install -t -v PACKAGE', but there is some discrepancy between the packages reported by `OPAMBUILDTEST=true opam list --required-by PACKAGE` and `opam install -v -t PACKAGE`.

As a concrete example this happens for `conduit` with the updated CI script:
```
opam install  async_ssl lwt mirage-dns ssl tls "base-bytes" "base-ocamlbuild" "base-unix" "base64" "camlp4" "cmdliner" "conf-m4" "conf-ncurses" "conf-pkg-conf
ig" "conf-which" "cppo" "cstruct" "ipaddr" "js-build-tools" "js_of_ocaml" "logs" "lwt" "menhir" "mtime" "ocamlbuild" "ocamlfind" "ocplib-endian" "optcomp" "ou
nit" "ppx_core" "ppx_deriving" "ppx_driver" "ppx_optcomp" "ppx_sexp_conv" "ppx_tools" "ppx_type_conv" "qcheck" "qtest" "re" "result" "sexplib" "stringext" "to
pkg" "type_conv" "uchar" "uri"
[....]

opam install conduit "-t" "-v"
=-=- Synchronising pinned packages =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[conduit: local] Command started
[conduit] /repo/ synchronized
The following actions will be performed:
  - downgrade stringext      1.4.3 to 1.4.2                     [required by conduit]
  - install   ctypes-foreign 0.4.0         
  - install   mirage-vnetif  0.2.0         
  - install   pcap-format    0.4.0                              [required by dns]
  - install   mirage-flow    1.1.0         
  - recompile uri            1.9.2                              [uses stringext]
  - recompile ctypes         0.11.1        
  - recompile dns            0.18.1                             [uses uri]
  - recompile async_ssl      113.33.07     
  - recompile mirage-dns     2.5.0                              [uses dns]
  - install   conduit        0.13.0*       
===== 5 to install | 5 to recompile | 1 to downgrade =====
```

Looks like this is due to test-only dependecies of `conduit`'s dependencies.