### PR TITLE
Run depopts tests jq

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -25,9 +25,11 @@ echo WORKDIR /home/opam/opam-repository >> Dockerfile
 echo RUN git pull origin master >> Dockerfile
 
 if [ $fork_user != $default_user -o $fork_branch != $default_branch ]; then
-    echo RUN opam pin add travis-opam \
+    echo RUN opam remove travis-opam >> Dockerfile
+    echo RUN opam pin add -n travis-opam \
          https://github.com/$fork_user/ocaml-ci-scripts.git#$fork_branch \
          >> Dockerfile
+    echo RUN opam depext -i travis-opam >> Dockerfile
 fi
 
 echo RUN opam update -u -y >> Dockerfile

--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 # To use this, run `opam travis --help`
 
+echo -en "travis_fold:start:prepare.ci\r"
 default_user=ocaml
 default_branch=master
 
@@ -47,4 +48,5 @@ echo docker run --env-file=env.list -v ${OS}:/repo local-build travis-opam
 
 # run ci-opam with the local repo volume mounted
 chmod -R a+w $OS
+echo -en "travis_fold:end:prepare.ci\r"
 docker run --env-file=env.list -v ${OS}:/repo local-build ci-opam

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -73,6 +73,7 @@ install_on_linux () {
      "$(full_apt_version ocaml-nox $OCAML_VERSION)" \
      "$(full_apt_version camlp4 $OCAML_VERSION)" \
      "$(full_apt_version camlp4-extra $OCAML_VERSION)" \
+     jq \
      opam
 
   TRUSTY="deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe"
@@ -115,6 +116,7 @@ install_on_osx () {
     *) echo "Unknown OCAML_VERSION=$OCAML_VERSION OPAM_VERSION=$OPAM_VERSION"
        exit 1 ;;
   esac
+  brew install jq
 }
 
 case $TRAVIS_OS_NAME in

--- a/.travis-opam.sh
+++ b/.travis-opam.sh
@@ -1,3 +1,4 @@
+echo -en "travis_fold:start:prepare.ci\r"
 # If a fork of these scripts is specified, use that GitHub user instead
 fork_user=${FORK_USER:-ocaml}
 
@@ -33,4 +34,5 @@ ocamlfind ocamlc -c yorick.ml
 ocamlfind ocamlc -o ci-opam -package unix -linkpkg yorick.cmo ci_opam.ml
 cd -
 
+echo -en "travis_fold:end:prepare.ci\r"
 ${TMP_BUILD}/ci-opam

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P unzip -P git -P perl -P mingw64-x86_64-gcc-core"
+  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P unzip -P git -P perl -P mingw64-x86_64-gcc-core -P jq"
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/ci_opam.ml
+++ b/ci_opam.ml
@@ -100,7 +100,7 @@ let install ?(depopts="") ?(tests=false) args =
     if tests then
       with_opambuildtest install_depext
     else install_depext ();
-    ?|~ "opam install %s" deps
+    ?|~ "opam install --unset-root %s" deps
   end;
 
   let args = if tests then "-t" :: args else args in
@@ -112,13 +112,13 @@ let install ?(depopts="") ?(tests=false) args =
   begin match extra_deps with
     | [] -> ()
     | deps ->
-      ?|. "opam remove %s" (filter_base ((ql deps) *~ " "))
+      ?|. "opam remove -a %s" (filter_base ((ql deps) *~ " "))
   end
 
 let install_with_depopts depopts =
   install ~tests:tests_run ~depopts ["-v"];
   ?|~ "opam remove %s -v" pkg;
-  ?|~ "opam remove %s" (filter_base depopts)
+  ?|~ "opam remove -a %s" (filter_base depopts)
 
 let max_version package =
   let rec next_version last =

--- a/ci_opam.ml
+++ b/ci_opam.ml
@@ -46,7 +46,7 @@ let revdep_run = list (getenv_default "REVDEPS" "")
 let opam_lint = fuzzy_bool_of_string (getenv_default "OPAM_LINT" "true")
 
 (* other variables *)
-let extra_deps = some (getenv_default "EXTRA_DEPS" "")
+let extra_deps = list (getenv_default "EXTRA_DEPS" "")
 let pre_install_hook = getenv_default "PRE_INSTALL_HOOK" ""
 let post_install_hook = getenv_default "POST_INSTALL_HOOK" ""
 
@@ -69,28 +69,54 @@ let filter_base pkgs =
   let baseless = List.filter (fun pkg -> not (is_base pkg)) (list pkgs) in
   baseless *~ " "
 
-let install args =
-  begin match extra_deps with
-    | None -> ()
-    | Some deps ->
-      ?|. "opam depext -u %s" deps;
-      ?|. "opam install %s" deps
+let with_opambuildtest fn =
+  export "OPAMBUILDTEST" "1";
+  let res = fn () in
+  unset "OPAMBUILDTEST";
+  res
+
+let get_package_versions_from_json file =
+  let cmd = ~~ "jq -r '.[] | .[] | .install | select(. != null) | select(.name != \"%s\") |[.name, .version] | join(\".\")' <%s" in
+  lines (?|> cmd pkg file)
+
+let install ?(depopts="") ?(tests=false) args =
+  let install_deps = if tests then
+      (* 'opam install --deps-only' would run the tests too,
+       * which we don't want.
+       * Even if we'd run it without OPAMBUILDTEST the test-only
+       * dependencies would still run their tests during installataion
+       * `opam list --depends-on` doesn't list the test-only dependencies.
+       * *)
+      with_opambuildtest (fun () ->
+          let tmp = "solution.json" in
+          let pkgs = (pkg :: depopts :: extra_deps) *~ " " in
+          ?|~ "opam install --show-actions --json %s %s" tmp pkgs;
+          get_package_versions_from_json tmp
+        )
+    else extra_deps in
+  if install_deps <> [] then begin
+    let deps = (ql install_deps) *~ " " in
+    let install_depext () = ?|. "opam depext -u %s" deps in
+    if tests then
+      with_opambuildtest install_depext
+    else install_depext ();
+    ?|~ "opam install %s" deps
   end;
+
+  let args = if tests then "-t" :: args else args in
 
   ?|  pre_install_hook;
   ?|~ "opam install %s %s" pkg (ql args *~ " ");
   ?|  post_install_hook;
 
   begin match extra_deps with
-    | None -> ()
-    | Some deps ->
-      ?|. "opam remove %s" (filter_base deps)
+    | [] -> ()
+    | deps ->
+      ?|. "opam remove %s" (filter_base ((ql deps) *~ " "))
   end
 
 let install_with_depopts depopts =
-  ?|~ "opam depext -u %s" depopts;
-  ?|~ "opam install %s" depopts;
-  install ["-v"];
+  install ~tests:tests_run ~depopts ["-v"];
   ?|~ "opam remove %s -v" pkg;
   ?|~ "opam remove %s" (filter_base depopts)
 
@@ -104,11 +130,6 @@ let max_version package =
       | _ -> None
   in
   next_version (trim (?|> "opam show -f version %s" package))
-
-let with_opambuildtest fn =
-  export "OPAMBUILDTEST" "1";
-  fn ();
-  unset "OPAMBUILDTEST"
 
 ;; (* Go go go *)
 
@@ -160,13 +181,11 @@ begin (* Simple installation/removal test *)
 end;
 
 begin (* tests *)
-  if tests_run then
-    with_opambuildtest (fun () ->
-        ?|~ "opam depext -u %s" pkg;
-        ?|~ "opam install %s --deps-only" pkg;
-        install ["-v";"-t"];
-        ?|~ "opam remove %s -v" pkg)
-  else
+  if tests_run then begin
+    (* run tests only for this package *)
+    install ~tests:true ["-v"];
+    ?|~ "opam remove %s -v" pkg
+  end else
     echo "TESTS=false, skipping the test run.";
 end;
 

--- a/ci_opam.ml
+++ b/ci_opam.ml
@@ -118,7 +118,12 @@ let install ?(depopts="") ?(tests=false) args =
 let install_with_depopts depopts =
   install ~tests:tests_run ~depopts ["-v"];
   ?|~ "opam remove %s -v" pkg;
-  ?|~ "opam remove -a %s" (filter_base depopts)
+  ?|~ "opam remove -a %s" (filter_base depopts);
+  if tests_run then begin
+    install ~tests:false ~depopts ["-v"];
+    ?|~ "opam remove %s -v" pkg;
+    ?|~ "opam remove -a %s" (filter_base depopts);
+  end
 
 let max_version package =
   let rec next_version last =

--- a/opam
+++ b/opam
@@ -14,4 +14,15 @@ depends: [
   "ocamlfind"  {build}
 ]
 
+depexts: [
+  [["alpine"] ["jq"]]
+  [["centos"] ["jq"]]
+  [["debian"] ["jq"]]
+  [["fedora"] ["jq"]]
+  [["homebrew" "osx"] ["jq"]]
+  [["opensuse"] ["jq"]]
+  [["oraclelinux"] ["jq"]]
+  [["ubuntu"] ["jq"]]
+]
+
 build: [make]


### PR DESCRIPTION
Sorry for the delay. Here is take two on https://github.com/ocaml/ocaml-ci-scripts/pull/145 , using `jq` this time.

The Travis log folds may not belong in this PR, but might make it easier to read the Travis output, which is a lot longer now, and can be confusing on where each phase begins, hopefully the folds will help with that, let me know if I should make a separate PR for that.