### PR TITLE
attempt to fix appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,8 @@ environment:
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P unzip -P git -P perl -P mingw64-x86_64-gcc-core -P jq"
+  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P unzip -P git -P perl -P mingw64-x86_64-gcc-core"
+  - curl -L -o C:/cygwin/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/ci_opam.ml
+++ b/ci_opam.ml
@@ -76,7 +76,7 @@ let with_opambuildtest fn =
   res
 
 let get_package_versions_from_json file =
-  let cmd = ~~ "jq -r '.[] | .[] | .install | select(. != null) | select(.name != \"%s\") |[.name, .version] | join(\".\")' <%s" in
+  let cmd = ~~ "jq -r '.[]? | .[]? | .install? | select(. != null) | select(.name? != \"%s\") |[.name, .version] | join(\".\")' %s" in
   lines (?|> cmd pkg file)
 
 let install ?(depopts="") ?(tests=false) args =


### PR DESCRIPTION
jq from cygwin didn't run (exited with code 127), use binary from github instead.
Accept solution.json from opam 1.3.0 too (ignore extra fields).

Here is a [failed Appveyor build](https://ci.appveyor.com/project/edwintorok/ocaml-ci-scripts/build/1.0.1), and here is a [successful Appveyor build](https://ci.appveyor.com/project/edwintorok/ocaml-ci-scripts/build/1.0.20) after this patch, and a [successful Travis build](https://travis-ci.org/edwintorok/datakit/jobs/196032769).

When I tested my previous PR I only tested on Travis, Appveyor was using `ci_opam.ml` from master instead of my PR branch, the above test is with a fork of ocaml-ci-scripts explicitly pointed to my branch `test-appveyor`, and this PR is the fix `fix-appveyor` but without the commit that changes `FORK_USER/FORK_BRANCH` (so it'll likely fail on appveyor when run here).

I initially thought the exitcode 127 is due to the redirection (`<%s`),  but turns out it wasn't, there is something strange about cygwin on appveyor, e.g. just adding `-P curl` instead of `-P jq` makes `"%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"` itself fail with code 127 and no other output. Luckily curl is already installed on Appveyor.