### PR TITLE
travis_mirage: Do not force a mir- prefix for the XENIMG

### DIFF
--- a/travis_mirage.ml
+++ b/travis_mirage.ml
@@ -78,7 +78,7 @@ then begin
                    \  CheckHostIP no
                    \  UserKnownHostsFile=/dev/null"
   in
-  export "XENIMG" "mir-${XENIMG:-$TRAVIS_REPO_SLUG#mirage/mirage-}.xen";
+  export "XENIMG" "${XENIMG:-$TRAVIS_REPO_SLUG#mirage/mirage-}.xen";
   export "MIRDIR" "${MIRDIR:-src}";
   export "DEPLOYD" "${TRAVIS_REPO_SLUG#*/}-deployment";
 


### PR DESCRIPTION
Mirage3 removes this prefix. Older deployments have to set XENIMG to
include the prefix.

Need to determine what to do about backwards compatibility with existing users of this script before merging.