### PR TITLE
new appveyor setup

### DIFF
--- a/README-appveyor.md
+++ b/README-appveyor.md
@@ -15,6 +15,65 @@ Instructions:
 
 And that's it!
 
-### Options
+## Options
 
-Most of the options detailed in TravisCI scripts are valid.
+Most of the options detailed in [TravisCI scripts](/README-travis.md)
+are valid.
+
+### OPAM_SWITCH
+
+`OCAML_VERSION` is however handled differently. There are currently
+three
+[Windows ports of OCaml](https://github.com/ocaml/ocaml/blob/trunk/README.win32.adoc):
+
+- Native Microsoft (msvc)
+- Native Mingw-w64
+- Cygwin
+
+Each variant is available in a 32-bit and 64-bit version.
+
+The native mingw-w64 port is supported through cygwin's
+[mingw-w64 cross compiler](http://mingw-w64.org/doku.php/download/cygwin),
+the msvc version through
+[Visual Studio Community 2015](https://www.appveyor.com/docs/installed-software/#visual-studio-2015).
+The cygwin port is currently not supported by these scripts.
+
+You can choose between different ports and versions through the
+`OPAM_SWITCH` variable, e.g:
+
+```yaml
+environment:
+  matrix:
+    - OPAM_SWITCH: 4.04.0+msvc32
+    - OPAM_SWITCH: 4.03.0+mingw64c
+    # syntax: ${OCAML_VERSION}+${PORT}${WORD_SIZE}c?
+```
+
+Some versions are available as pre-compiled binaries to speed up the
+build process (the 'c'-suffix), but not all.
+
+If you don't specify `OPAM_SWITCH` manually, a recent, pre-compiled
+mingw port (64-bit) is used. The build instructions of many opam
+packages are only compatible with gcc.
+
+### Other environment variables
+
+#### CYG_ROOT
+
+Cygwin is used by `ocaml-ci-scripts` and nearly all opam packages
+depend on it.  By default, the 64-bit version is used. You can switch
+to the 32-bit version by setting `CYG_ROOT` to `C:\cygwin`.
+
+#### CYG_MIRROR
+
+Cygwin must be updated during the install step. The mirror for this
+task must be specified manually. If the mirror that is normally used
+goes offline or becomes too slow, you can point `CYG_MIRROR` to
+another [supported mirror](https://cygwin.com/mirrors.lst).
+
+#### CYG_PKGS
+
+If you need additional packages from cygwin, you can add them to
+`CYG_PKGS` (comma separated). By default, the `mingw64-x86_64`
+toolchain is updated. But for most use cases, you should rely on
+[depext-cygwinports](https://fdopen.github.io/opam-repository-mingw/depext-cygwin/).

--- a/appveyor-install.ps1
+++ b/appveyor-install.ps1
@@ -1,0 +1,82 @@
+$fork_user="ocaml"
+$fork_branch="master"
+$cyg_root="C:\cygwin64"
+$cyg_setup="setup-x86_64.exe"
+$cyg_mirror="http://cygwin.mirror.constant.com"
+$appveyor_build_folder=".\"
+$cyg_pkgs="mingw64-x86_64-gcc-core,mingw64-x86_64-headers,mingw64-x86_64-runtime,mingw64-x86_64-winpthreads"
+
+if ( Test-Path env:fork_user ){
+    $fork_user=$env:fork_user
+}
+if ( Test-Path env:fork_branch ){
+    $fork_branch=$env:fork_branch
+}
+$appveyor_opam_sh="https://raw.githubusercontent.com/$fork_user/ocaml-ci-scripts/$fork_branch/appveyor-opam.sh"
+
+if ( Test-Path env:cyg_pkgs ){
+    $cyg_pkgs=%{$env:cyg_pkgs -replace " ",","}
+}
+if ( Test-Path env:cyg_mirror ){
+    $cyg_mirror=$env:cyg_mirror
+}
+if ( Test-Path env:cyg_root ){
+    $cyg_root=$env:cyg_root
+    if ( $cyg_root -eq "C:\cygwin" ){
+        $cyg_setup="setup-x86.exe"
+    }
+}
+if ( Test-Path env:appveyor_build_folder ){
+    $appveyor_build_folder=$env:appveyor_build_folder
+}
+
+# add further regular cygwin programs
+function add_pkg($pkg){
+    if ($cyg_pkgs) {
+        $script:cyg_pkgs="$cyg_pkgs,$pkg"
+    } else {
+        $script:cyg_pkgs="$pkg"
+    }
+}
+
+function add_program($exe,$pkg_name){
+    if (!(Test-Path "$script:cyg_root\bin\$exe.exe")){
+        if ($pkg_name){
+            add_pkg $pkg_name
+        } else {
+            add_pkg $exe
+	}
+    }
+}
+
+add_program "curl"
+add_program "diff" "diffutils"
+add_program "git"
+add_program "jq"
+add_program "m4"
+add_program "make"
+add_program "patch"
+add_program "perl"
+add_program "rsync"
+add_program "unzip"
+#add_program "x86_64-w64-mingw32-gcc" "mingw64-x86_64-gcc-core"
+
+$appveyor_local="$appveyor_build_folder\appveyor-opam.sh"
+$webclient = New-Object System.Net.WebClient
+$webclient.DownloadFile($appveyor_opam_sh,$appveyor_local)
+
+$cont = [System.IO.File]::ReadAllText($appveyor_local).Replace("APPVEYOR_YML_VERSION=0","APPVEYOR_YML_VERSION=1")
+[System.IO.File]::WriteAllText($appveyor_local, $cont)
+
+if ($cyg_pkgs) {
+    # always update cygwin, too. Otherwise the the new package might be incompatible
+    # with the pre-installed cygwin1.dll
+    $cyg_pkgs="cygwin,$cyg_pkgs"
+    if (!(Test-Path "$cyg_root\$cyg_setup")){
+        if (!(Test-Path "$cyg_root")){
+            md "$cyg_root"
+        }
+        $webclient.DownloadFile("https://cygwin.com/$cyg_setup","$cyg_root\$cyg_setup")
+    }
+    & "$cyg_root\$cyg_setup" -qWnNdO -R $cyg_root -s $cyg_mirror -l $cyg_root\var\cache\setup -P $cyg_pkgs | Out-Host
+}

--- a/appveyor-opam.sh
+++ b/appveyor-opam.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+APPVEYOR_YML_VERSION=0
+
 # If a fork of these scripts is specified, use that GitHub user instead
 fork_user=${FORK_USER:-ocaml}
 
@@ -8,12 +10,12 @@ fork_branch=${FORK_BRANCH:-master}
 
 # default setttings
 SWITCH=${OPAM_SWITCH:-'4.03.0+mingw64c'}
-OPAM_URL='https://dl.dropboxusercontent.com/s/b2q2vjau7if1c1b/opam64.tar.xz'
+OPAM_URL='https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.1/opam64.tar.xz'
 OPAM_ARCH=opam64
 
 if [ "$PROCESSOR_ARCHITECTURE" != "AMD64" ] && \
        [ "$PROCESSOR_ARCHITEW6432" != "AMD64" ]; then
-    OPAM_URL='https://dl.dropboxusercontent.com/s/eo4igttab8ipyle/opam32.tar.xz'
+    OPAM_URL='https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.1/opam32.tar.xz'
     OPAM_ARCH=opam32
 fi
 
@@ -26,36 +28,69 @@ export CYGWIN='winsymlinks:native'
 export OPAMYES=1
 
 get() {
-  wget https://raw.githubusercontent.com/${fork_user}/ocaml-ci-scripts/${fork_branch}/$@
+  wget --quiet https://raw.githubusercontent.com/${fork_user}/ocaml-ci-scripts/${fork_branch}/$@
 }
 
 set -eu
 
 curl -fsSL -o "${OPAM_ARCH}.tar.xz" "${OPAM_URL}"
 tar -xf "${OPAM_ARCH}.tar.xz"
-"${OPAM_ARCH}/install.sh"
+"${OPAM_ARCH}/install.sh" --quiet
+
+if [ "$APPVEYOR_YML_VERSION" != "0" ]; then
+    # The default PATH contains far too many folders. There is always
+    # a risk, that a tool is picked from the wrong location. It
+    # happend in the past with unzip. It also slows down cygwin.
+    PATH=/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0
+    export PATH
+    set +eu
+    # see https://www.appveyor.com/docs/build-configuration/#build-environment
+    # currently NUMBER_OF_PROCESSORS matches these settings
+    if [ -z "$OPAMJOBS" ]; then
+        if echo "$NUMBER_OF_PROCESSORS" | egrep -q '^[0-9]+$' ; then
+            if [ $NUMBER_OF_PROCESSORS -gt 1 ]; then
+                export OPAMJOBS=$NUMBER_OF_PROCESSORS
+            fi
+        fi
+    fi
+    set -eu
+fi
+
+# if a msvc compiler must be compiled from source, we have to modify the
+# environment first
+case "$SWITCH" in
+    *msvc32)
+        eval $(ocaml-env cygwin --ms=vs2015 --no-opam --32)
+        ;;
+    *msvc64)
+        eval $(ocaml-env cygwin --ms=vs2015 --no-opam --64)
+        ;;
+esac
 
 opam init -a default "https://github.com/fdopen/opam-repository-mingw.git" --comp "$SWITCH" --switch "$SWITCH"
-eval $(opam config env)
-ocaml_system="$(ocamlc -config | awk '/^system:/ { print $2 }')"
-case "$ocaml_system" in
-    *mingw64*)
-        PATH="/usr/x86_64-w64-mingw32/sys-root/mingw/bin:${PATH}"
-        export PATH
+is_msvc=0
+case "$SWITCH" in
+    *msvc*)
+        is_msvc=1
+        eval $(ocaml-env cygwin --ms=vs2015)
         ;;
     *mingw*)
-        PATH="/usr/i686-w64-mingw32/sys-root/mingw/bin:${PATH}"
-        export PATH
+        eval $(ocaml-env cygwin)
         ;;
     *)
         echo "ocamlc reports a dubious system: ${ocaml_system}. Good luck!" >&2
+        eval $(opam config env)
 esac
-opam install depext-cygwinports depext ocamlfind
-eval $(opam config env)
+if [ $is_msvc -eq 0 ]; then
+    opam install depext-cygwinports depext ocamlfind
+else
+    opam install depext ocamlfind
+fi
 
 TMP_BUILD=$(mktemp -d 2>/dev/null || mktemp -d -t 'citmpdir')
 cd "${TMP_BUILD}"
 
+echo "downloading ocaml-ci-scripts from github.com/${fork_user}/ocaml-ci-scripts/${fork_branch}" >&2
 get ci_opam.ml
 get yorick.mli
 get yorick.ml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,12 @@ platform:
   - x86
 
 environment:
-  CYG_ROOT: "C:\\cygwin"
-  CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
+  FORK_USER: ocaml
+  FORK_BRANCH: master
+  CYG_ROOT: C:\cygwin64
 
 install:
-  - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P git -P perl -P mingw64-x86_64-gcc-core"
-  - curl -L -o C:/cygwin/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))
 
 build_script:
-  - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"
+  - call %CYG_ROOT%\bin\bash.exe -l %APPVEYOR_BUILD_FOLDER%\appveyor-opam.sh


### PR DESCRIPTION
I've improved th appveyor setup:

- The basic install step is now managed by the this repo instead of the individual `appveyor.yml` files. Cygwin is a rolling release, so workarounds are frequently necessary (like in the case of `jq` or `unzip`). A script is now downloaded and executed during the install step. If something must be changed, it can be updated centrally. The script is more verbose and should be able to deal with most changes itself.

- cygwin64 is used instead of cygwin32. cygwin64 is more reliable (less fork failures); it shouldn't make a difference performance-wise.

- OPAMJOBS is set to the number of processors provided by appveyor.

- the msvc toolchain is now supported by `appveyor-opam.sh`.

- README-appveyor.md was updated to reflect these changes.

The changes are backward compatible. Users who don't update their `appveyor.yml`, won't be affected. If something is wrong with `appveyor-install.ps1`, they won't notice it.

The CI run will likely fail for this pull request, because `appveyor-install.ps1` is not yet available.

example runs with the old setup: https://ci.appveyor.com/project/fdopen/irmin/build/1.0.2 / https://ci.appveyor.com/project/fdopen/irmin/build/1.0.5

example runs with the new setup: https://ci.appveyor.com/project/fdopen/irmin/build/1.0.3 / https://ci.appveyor.com/project/fdopen/irmin/build/1.0.6

It seems to be faster. But testing virtualized environments that are not under your control is difficult. If you notice any slow down, we can change the default settings for OPAMJOBS and cygwin64 vs cygwin later again.