### PR TITLE
homebrew switched to 4.06.0 by default, update travis scripts

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -116,7 +116,8 @@ install_on_osx () {
     4.02,1.3.0) OPAM_SWITCH=4.02.3; brew install opam --HEAD ;;
     4.03,1.2.2) OPAM_SWITCH=4.03.0; brew install opam ;;
     4.04,1.2.2) OPAM_SWITCH=4.04.2; brew install opam ;;
-    4.05,1.2.2) OPAM_SWITCH=system; brew install ocaml; brew install opam ;;
+    4.05,1.2.2) OPAM_SWITCH=4.05.0; brew install opam ;;
+    4.06,1.2.2) OPAM_SWITCH=system; brew install ocaml; brew install opam ;;
     *) echo "Unknown OCAML_VERSION=$OCAML_VERSION OPAM_VERSION=$OPAM_VERSION"
        exit 1 ;;
   esac


### PR DESCRIPTION
With the current state, 4.05.0 uses homebrew "system" switch, which
results in 4.06.0 being actually used for testing. This resulted in
a bytes/string-related build failure under "OSX 4.05.0" for why3-base:

  https://travis-ci.org/ocaml/opam-repository/jobs/300508089

> Setting environment variables from .travis.yml
> $ export OCAML_VERSION=4.05
> $ export OPAM_VERSION=1.2.2
> [...]
> OCaml version
> The OCaml toplevel, version 4.06.0