### PR TITLE
flags; cd fix

### DIFF
--- a/src/travis_mirage.ml
+++ b/src/travis_mirage.ml
@@ -28,6 +28,9 @@ let extra_remotes = list (getenv_default "EXTRA_REMOTES" "")
 (* Any extra pins to use *)
 let pins = list (getenv_default "PINS" "")
 
+(* Directory in which to build the unikernel *)
+let dir = getenv_default "SRC_DIR" "."
+
 (* Mirage deployment environment *)
 let (|>) a b = b a
 let is_deploy = getenv_default "DEPLOY" "false" |> fuzzy_bool_of_string
@@ -60,11 +63,11 @@ export "OPAMYES" "1";
 List.iter add_remote extra_remotes;
 
 List.iter pin pins;
+cd dir;
 ?| "eval $(opam config env)";
 
 ?| "opam update -u";
 ?| "opam install 'mirage>=3.0.0'";
-?| {| [ -n "$SRC_DIR" ] && cd "$SRC_DIR" |};
 ?| "mirage configure -t $MIRAGE_BACKEND $FLAGS";
 ?| "make depend";
 ?| "make";

--- a/src/travis_mirage.ml
+++ b/src/travis_mirage.ml
@@ -65,7 +65,7 @@ List.iter pin pins;
 ?| "opam update -u";
 ?| "opam install 'mirage>=3.0.0'";
 ?| {| [ -n "$SRC_DIR" ] && cd "$SRC_DIR" |};
-?| "mirage configure -t $MIRAGE_BACKEND";
+?| "mirage configure -t $MIRAGE_BACKEND $FLAGS";
 ?| "make depend";
 ?| "make";
 ?| "echo TRAVIS_BRANCH=$TRAVIS_BRANCH"


### PR DESCRIPTION
The previous `cd` doesn't actually descend into the given directory.  Use one that does.

[before](https://travis-ci.org/mirage/mirage-www/jobs/310990415) [after](https://travis-ci.org/mirage/mirage-www/jobs/310990414)