### PR TITLE
allow the user to specify the Docker hub user from which to get the base image

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -4,9 +4,11 @@
 echo -en "travis_fold:start:prepare.ci\r"
 default_user=ocaml
 default_branch=master
+default_hub_user=ocaml
 
 fork_user=${FORK_USER:-$default_user}
 fork_branch=${FORK_BRANCH:-$default_branch}
+hub_user=${HUB_USER:-$default_hub_user}
 
 # create env file
 echo PACKAGE="$PACKAGE" > env.list
@@ -22,7 +24,7 @@ echo POST_INSTALL_HOOK="$POST_INSTALL_HOOK" >> env.list
 echo $EXTRA_ENV >> env.list
 
 # build a local image to trigger any ONBUILDs
-echo FROM ocaml/opam:${DISTRO}_ocaml-${OCAML_VERSION} > Dockerfile
+echo FROM ${hub_user}/opam:${DISTRO}_ocaml-${OCAML_VERSION} > Dockerfile
 echo WORKDIR /home/opam/opam-repository >> Dockerfile
 
 if [ -n "$BASE_REMOTE" ]; then


### PR DESCRIPTION
I've uploaded some Docker images for OCaml build environments with opam that include the +afl compiler variants (as well as afl tooling).  I'd like to use these as base images for workflows with `.travis-docker.sh`, which is possible if I can specify the hub user who should be hosting the base image.