### PR TITLE
INSTALL_LOCAL option: allowing a specific compiler to be tested as a "system" compiler

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -18,7 +18,6 @@ set -uex
 OCAML_VERSION=${OCAML_VERSION:-latest}
 OPAM_VERSION=${OPAM_VERSION:-1.2.2}
 OPAM_INIT=${OPAM_INIT:-true}
-OPAM_SWITCH=${OPAM_SWITCH:-system}
 
 # the base opam repository to use for bootstrapping and catch-all namespace
 BASE_REMOTE=${BASE_REMOTE:-git://github.com/ocaml/opam-repository}
@@ -39,29 +38,29 @@ esac
 install_on_linux () {
   case "$OCAML_VERSION,$OPAM_VERSION" in
     3.12,1.2.2)
-       OCAML_VERSION=4.02; OPAM_SWITCH="3.12.1"
+       OCAML_VERSION=4.02; OCAML_FULL_VERSION=3.12.1
        ppa=avsm/ocaml42+opam12 ;;
     4.00,1.2.2)
-       OCAML_VERSION=4.02; OPAM_SWITCH="4.00.1"
+       OCAML_VERSION=4.02; OCAML_FULL_VERSION=4.00.1
        ppa=avsm/ocaml42+opam12 ;;
     4.01,1.2.2)
-       OCAML_VERSION=4.02; OPAM_SWITCH="4.01.0"
+       OCAML_VERSION=4.02; OCAML_FULL_VERSION=4.01.0
        ppa=avsm/ocaml42+opam12 ;;
-    4.02,1.1.2) OPAM_SWITCH=4.02.3; ppa=avsm/ocaml42+opam11 ;;
-    4.02,1.2.0) OPAM_SWITCH=4.02.3; ppa=avsm/ocaml42+opam120 ;;
-    4.02,1.2.1) OPAM_SWITCH=4.02.3; ppa=avsm/ocaml42+opam121 ;;
-    4.02,1.2.2) ppa=avsm/ocaml42+opam12 ;;
+    4.02,1.1.2) OCAML_FULL_VERSION=4.02.3; OPAM_SWITCH=${OPAM_SWITCH:-system}; ppa=avsm/ocaml42+opam11 ;;
+    4.02,1.2.0) OCAML_FULL_VERSION=4.02.3; OPAM_SWITCH=${OPAM_SWITCH:-system}; ppa=avsm/ocaml42+opam120 ;;
+    4.02,1.2.1) OCAML_FULL_VERSION=4.02.3; OPAM_SWITCH=${OPAM_SWITCH:-system}; ppa=avsm/ocaml42+opam121 ;;
+    4.02,1.2.2) OCAML_FULL_VERSION=4.02.3; OPAM_SWITCH=${OPAM_SWITCH:-system}; ppa=avsm/ocaml42+opam12 ;;
     4.03,1.2.2)
-       OCAML_VERSION=4.02; OPAM_SWITCH="4.03.0";
+       OCAML_VERSION=4.02; OCAML_FULL_VERSION=4.03.0
        ppa=avsm/ocaml42+opam12 ;;
     4.04,1.2.2)
-        OCAML_VERSION=4.02; OPAM_SWITCH="4.04.2"
+        OCAML_VERSION=4.02; OCAML_FULL_VERSION=4.04.2
         ppa=avsm/ocaml42+opam12 ;;
     4.05,1.2.2)
-        OCAML_VERSION=4.02; OPAM_SWITCH="4.05.0"
+        OCAML_VERSION=4.02; OCAML_FULL_VERSION=4.05.0
         ppa=avsm/ocaml42+opam12 ;;
     4.06,1.2.2)
-        OCAML_VERSION=4.02; OPAM_SWITCH="4.06.0"
+        OCAML_VERSION=4.02; OCAML_FULL_VERSION=4.06.0
         ppa=avsm/ocaml42+opam12 ;;
     *) echo "Unknown OCAML_VERSION=$OCAML_VERSION OPAM_VERSION=$OPAM_VERSION"
        exit 1 ;;
@@ -112,15 +111,15 @@ install_on_osx () {
   esac
   brew update &> /dev/null
   case "$OCAML_VERSION,$OPAM_VERSION" in
-    3.12,1.2.2) OPAM_SWITCH=3.12.1; brew install opam ;;
-    4.00,1.2.2) OPAM_SWITCH=4.00.1; brew install opam ;;
-    4.01,1.2.2) OPAM_SWITCH=4.01.0; brew install opam ;;
-    4.02,1.2.2) OPAM_SWITCH=4.02.3; brew install opam ;;
-    4.02,1.3.0) OPAM_SWITCH=4.02.3; brew install opam --HEAD ;;
-    4.03,1.2.2) OPAM_SWITCH=4.03.0; brew install opam ;;
-    4.04,1.2.2) OPAM_SWITCH=4.04.2; brew install opam ;;
-    4.05,1.2.2) OPAM_SWITCH=4.05.0; brew install opam ;;
-    4.06,1.2.2) OPAM_SWITCH=system; brew install ocaml; brew install opam ;;
+    3.12,1.2.2) OCAML_FULL_VERSION=3.12.1; brew install opam ;;
+    4.00,1.2.2) OCAML_FULL_VERSION=4.00.1; brew install opam ;;
+    4.01,1.2.2) OCAML_FULL_VERSION=4.01.0; brew install opam ;;
+    4.02,1.2.2) OCAML_FULL_VERSION=4.02.3; brew install opam ;;
+    4.02,1.3.0) OCAML_FULL_VERSION=4.02.3; brew install opam --HEAD ;;
+    4.03,1.2.2) OCAML_FULL_VERSION=4.03.0; brew install opam ;;
+    4.04,1.2.2) OCAML_FULL_VERSION=4.04.2; brew install opam ;;
+    4.05,1.2.2) OCAML_FULL_VERSION=4.05.0; brew install opam ;;
+    4.06,1.2.2) OCAML_FULL_VERSION=4.06.0; OPAM_SWITCH=${OPAM_SWITCH:-system}; brew install ocaml; brew install opam ;;
     *) echo "Unknown OCAML_VERSION=$OCAML_VERSION OPAM_VERSION=$OPAM_VERSION"
        exit 1 ;;
   esac
@@ -131,6 +130,8 @@ case $TRAVIS_OS_NAME in
     osx) install_on_osx ;;
     linux) install_on_linux ;;
 esac
+
+OPAM_SWITCH=${OPAM_SWITCH:-$OCAML_FULL_VERSION}
 
 export OPAMYES=1
 

--- a/README-travis.md
+++ b/README-travis.md
@@ -3,7 +3,7 @@
 ## Plain OCaml Install, `.travis-ocaml.sh`
 
 This is a helper script that simply installs the Ubuntu OCaml compiler packages,
-including Camlp4, plus OPAM. This is fetched and executed by the other Travis
+including Camlp4, plus opam. This is fetched and executed by the other Travis
 scripts in this repo. Set the `OCAML_VERSION` variable to the desired version,
 e.g.,
 
@@ -25,19 +25,26 @@ env:
 Add one line per compiler version you want to test. The `[...]` are other
 environments variables set for this Travis CI run.
 
-### Changing the Base OPAM Remote
+### Changing the Base opam Remote
 
 ```yaml
 env:
-  - [...] BASE_REMOTE=<url> [...]
+pick  - [...] BASE_REMOTE=<url> [...]
 ```
 
-The bare-bones install script can be configured to initialize OPAM with
-a metadata repository that isn't the default community OPAM remote of
+The bare-bones install script can be configured to initialize opam with
+a metadata repository that isn't the default community opam remote of
 [git://github.com/ocaml/opam-repository](git://github.com/ocaml/opam-repository).
-`BASE_REMOTE` initializes OPAM with a repository address of your choice.
+`BASE_REMOTE` initializes opam with a repository address of your choice.
 
-## OPAM Package, `.travis-opam.sh`
+### Testing a specific switch
+
+The `OCAML_VERSION` variable will select the latest release of that version. If
+you require a specific release (for example a beta or release candidate), you
+can set `OPAM_SWITCH` to the precise compiler to be used. `OPAM_SWITCH` takes
+precedence over `OCAML_VERSION`.
+
+## opam Package, `.travis-opam.sh`
 
 Instructions:
 
@@ -89,7 +96,7 @@ This information is read from the `opam` file per default, but it is also
 possible to specify sets of optional dependencies that will be tried instead,
 e.g. for testing multiple configurations with different set of dependencies.
 These package names do not need to be defined in the `opam` file, they can be
-any package in the OPAM repository.
+any package in the opam repository.
 
 ```yaml
 env:
@@ -148,16 +155,16 @@ env:
   - [...] REVDEPS="<list of space-separated package names>" [...]
 ```
 
-### Customizing the OPAM Pin Set
+### Customizing the opam Pin Set
 
 ```yaml
 env:
   - [...] PINS="<list of space-separated name:url pin pairs>" [...]
 ```
 
-You can customize the development pins of an OPAM package test run with
+You can customize the development pins of an opam package test run with
 the `PINS` variable. Each pin specified will *only* result in that pin
-being added into OPAM's pin set -- no default installation will be
+being added into opam's pin set -- no default installation will be
 performed. A pin of a package name without a colon (":") will result in
 that package being pinned to the URL in that package's `dev-repo`
 field. A pin of a `name:url` or `name.version:url` pair will pin the
@@ -178,7 +185,7 @@ These only get executed when installing your package, not the dependencies.
 The hook functionality might be useful for running commands like OASIS to
 generate build files which are not checked into the repository.
 
-### Changing OPAM Remotes
+### Changing opam Remotes
 
 ```yaml
 env:
@@ -186,7 +193,7 @@ env:
 ```
 
 In addition to changing the `BASE_REMOTE` to configure an initialization
-repository, `.travis-opam.sh` users can layer additional OPAM remotes on top
+repository, `.travis-opam.sh` users can layer additional opam remotes on top
 of the `BASE_REMOTE` with `EXTRA_REMOTES`. Remotes are added from left
 to right.
 
@@ -224,13 +231,13 @@ Configuration choices are passed to `mirage configure` via environment variables
 + `MIRAGE_BACKEND=[unix|xen|qubes|virtio|ukvm|macosx]`: selects Mirage backend mode
 + `FLAGS`: other configuration flags to set in `mirage configure`
 
-### Changing the version of OPAM
+### Changing the version of opam
 
 ```yaml
   - [...] OPAM_VERSION="1.1.2"
 ```
 
-By default, the latest stable version of OPAM will be used. The scripts supports
+By default, the latest stable version of opam will be used. the scripts supports
 these version:
 
 - `OPAM_VERSION=1.1.2` only when the OS is `unix` (default)

--- a/README-travis.md
+++ b/README-travis.md
@@ -44,6 +44,21 @@ you require a specific release (for example a beta or release candidate), you
 can set `OPAM_SWITCH` to the precise compiler to be used. `OPAM_SWITCH` takes
 precedence over `OCAML_VERSION`.
 
+### Testing system switches
+
+It is possible to test a specific compiler as though it were a system switch by
+setting the environment variable `INSTALL_LOCAL` to `1`. In this case,
+`OPAM_SWITCH` must be either empty, un-set or `system`. The script will compile
+the latest release of `OCAML_VERSION` and install it to `/usr/local/` which opam
+will then pick up as a system compiler instead of the Ubuntu-installed OCaml.
+
+This process does not install camlp4, though Ubuntu does (at least at present)
+install camlp4 4.02.3 with opam. If you require camlp4 for the compiler, you
+will need to install it as part of your test script using opam.
+
+At present, this feature is only available on Ubuntu Travis images and will
+return an error if specified for a macOS image.
+
 ## opam Package, `.travis-opam.sh`
 
 Instructions:


### PR DESCRIPTION
This PR achieves the dual purpose of addressing my request in #175 which will allow, for example, the first beta of OCaml 4.07.0 to be tested in a Travis matrix and also builds on this tweak to provide a new option `INSTALL_LOCAL` for the Linux hosts which instead of switching to a particular OCaml version will instead compile it locally, install it to `/usr/local` and then have opam use that compiler as a `system` switch.

The primary motivation of this is opam-repository continuous testing of system installation on a platform with "normal" security (i.e. not macOS).

The support can probably be extended to osx hosts, but it's not necessary for what I'm after as brew tracks latest OCaml already and the inability to virtualise macOS makes it more of a pain to test than even I am willing to endure...