### PR TITLE
remove "latest"; echo more help when OCAML_VERSION not set

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -32,10 +32,6 @@ UBUNTU_TRUSTY=${UBUNTU_TRUSTY:-"0"}
 # Install XQuartz on OSX
 INSTALL_XQUARTZ=${INSTALL_XQUARTZ:-"true"}
 
-case "$OCAML_VERSION" in
-    latest) OCAML_VERSION=4.02;;
-esac
-
 install_on_linux () {
   case "$OCAML_VERSION,$OPAM_VERSION" in
     3.12,1.2.2)
@@ -64,6 +60,8 @@ install_on_linux () {
         OCAML_VERSION=4.02; OPAM_SWITCH="4.06.0"
         ppa=avsm/ocaml42+opam12 ;;
     *) echo "Unknown OCAML_VERSION=$OCAML_VERSION OPAM_VERSION=$OPAM_VERSION"
+       echo "(An unset OCAML_VERSION used to default to \"latest\", but you must now specify it."
+       echo "Try something like \"OCAML_VERSION=3.12\", \"OCAML_VERSION=4.06\", or see README-travis.md at https://github.com/ocaml/ocaml-ci-scripts )"
        exit 1 ;;
   esac
 

--- a/README-travis.md
+++ b/README-travis.md
@@ -12,6 +12,12 @@ env:
   - OCAML_VERSION=4.02 [...]
 ```
 
+**Note:** Setting the `OCAML_VERSION` to `latest` is no longer valid, and there is
+no default `OCAML_VERSION`; you must set one, either per-entry or once in the global
+section for all tests.  For discussion, please see
+[the issue](https://github.com/ocaml/ocaml-ci-scripts/issues/110) in which
+updating `OCAML_VERSION` from version 4.02.3 was initially proposed.
+
 ### Testing Multiple Compilers
 
 ```yaml


### PR DESCRIPTION
Implements the apparent community consensus in https://github.com/ocaml/ocaml-ci-scripts/issues/110 .  You can see what this looks like for a user who was still trying to use `OCAML_VERSION=latest` at https://travis-ci.org/yomimono/mirage-tcpip/jobs/331934124#L486 .