### PR TITLE
fix travis-docker: always remove travis-opam and install anew with depext

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -33,13 +33,13 @@ else
 fi
 
 
+echo RUN opam remove travis-opam >> Dockerfile
 if [ $fork_user != $default_user -o $fork_branch != $default_branch ]; then
-    echo RUN opam remove travis-opam >> Dockerfile
     echo RUN opam pin add -n travis-opam \
          https://github.com/$fork_user/ocaml-ci-scripts.git#$fork_branch \
          >> Dockerfile
-    echo RUN opam depext -i travis-opam >> Dockerfile
 fi
+echo RUN opam depext -i travis-opam >> Dockerfile
 
 echo RUN opam update -u -y >> Dockerfile
 echo VOLUME /repo >> Dockerfile


### PR DESCRIPTION
Fix for #205 .  [before](https://travis-ci.org/yomimono/ocaml-cstruct/builds/332473642), [after](https://travis-ci.org/yomimono/ocaml-cstruct/builds/332573338) (`debian-unstable` failed to download a dependency of `jq` upstream in the "after" link, but the other distros are able to set up and run tests successfully.)