### PR TITLE
update opam before pulling a new travis-opam

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -39,9 +39,9 @@ if [ $fork_user != $default_user -o $fork_branch != $default_branch ]; then
          https://github.com/$fork_user/ocaml-ci-scripts.git#$fork_branch \
          >> Dockerfile
 fi
-echo RUN opam depext -i travis-opam >> Dockerfile
 
 echo RUN opam update -u -y >> Dockerfile
+echo RUN opam depext -ui travis-opam >> Dockerfile
 echo VOLUME /repo >> Dockerfile
 echo WORKDIR /repo >> Dockerfile
 docker build -t local-build .


### PR DESCRIPTION
#205 [isn't fixed](https://travis-ci.org/yomimono/ocaml-cstruct/jobs/332473643#L4584) because we don't have an updated package definition for `travis-opam` at the time we run `depext -i`.  (It appears to work when testing with `FORK_USER` and `FORK_BRANCH` because in that case, we pin before updating, and therefore get a new package definition.)

Try, try again.