### PR TITLE
Replace the dependency over jq by jsonm

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -42,6 +42,9 @@ fi
 
 echo RUN opam update -u -y >> Dockerfile
 echo RUN opam depext -ui travis-opam >> Dockerfile
+echo RUN cp "~/.opam/${OCAML_VERSION}/bin/ci-opam" "~/" >> Dockerfile
+echo RUN opam remove -a travis-opam >> Dockerfile
+echo RUN mv "~/ci-opam" "~/.opam/${OCAML_VERSION}/bin/ci-opam" >> Dockerfile
 echo VOLUME /repo >> Dockerfile
 echo WORKDIR /repo >> Dockerfile
 docker build -t local-build .

--- a/.travis-mirage.sh
+++ b/.travis-mirage.sh
@@ -29,6 +29,7 @@ opam install ocamlfind
 ocamlc.opt yorick.mli
 ocamlfind ocamlc -c yorick.ml
 ocamlfind ocamlc -o travis-mirage -package unix -linkpkg yorick.cmo travis_mirage.ml
+opam remove ocamlfind
 cd -
 
 ${TMP_BUILD}/travis-mirage

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -89,10 +89,9 @@ install_on_linux () {
        "$(full_apt_version ocaml-nox $OCAML_VERSION)" \
        "$(full_apt_version camlp4 $OCAML_VERSION)" \
        "$(full_apt_version camlp4-extra $OCAML_VERSION)" \
-       jq \
        opam
   else
-    sudo apt-get install -y jq opam
+    sudo apt-get install -y opam
   fi
 
   TRUSTY="deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe"
@@ -149,7 +148,6 @@ install_on_osx () {
     *) echo "Unknown OCAML_VERSION=$OCAML_VERSION OPAM_VERSION=$OPAM_VERSION"
        exit 1 ;;
   esac
-  brew install jq
 }
 
 case $TRAVIS_OS_NAME in

--- a/.travis-opam.sh
+++ b/.travis-opam.sh
@@ -21,6 +21,9 @@ eval $(opam config env)
 
 opam depext -y conf-m4
 opam pin add travis-opam https://github.com/${fork_user}/ocaml-ci-scripts.git#${fork_branch}
+cp ~/.opam/$(opam switch show)/bin/ci-opam ~/
+opam remove -a travis-opam
+mv ~/ci-opam ~/.opam/$(opam switch show)/bin/ci-opam
 
 echo -en "travis_fold:end:prepare.ci\r"
 opam config exec -- ci-opam

--- a/appveyor-install.ps1
+++ b/appveyor-install.ps1
@@ -52,7 +52,6 @@ function add_program($exe,$pkg_name){
 add_program "curl"
 add_program "diff" "diffutils"
 add_program "git"
-add_program "jq"
 add_program "m4"
 add_program "make"
 add_program "patch"

--- a/appveyor-opam.sh
+++ b/appveyor-opam.sh
@@ -86,9 +86,9 @@ case "$SWITCH" in
         eval $(opam config env)
 esac
 if [ $is_msvc -eq 0 ]; then
-    opam install depext-cygwinports depext ocamlfind
+    opam install depext-cygwinports depext
 else
-    opam install depext ocamlfind
+    opam install depext
 fi
 
 export OPAMYES=1
@@ -101,4 +101,5 @@ cd "${APPVEYOR_BUILD_FOLDER}"
 
 # copy the binaries to allow removal of the travis-opam package
 opam config exec -- cp $(which ci-opam.exe) ci-opam.exe
+opam remove -a travis-opam
 "${APPVEYOR_BUILD_FOLDER}"/ci-opam.exe

--- a/src/jbuild
+++ b/src/jbuild
@@ -5,7 +5,7 @@
    (modules     (ci_opam))
    (public_name ci-opam)
 ;   (flags        (:standard -cclib -static))
-   (libraries    (yorick))))
+   (libraries    (yorick jsonm))))
 
 (executable
   ((name        travis_mirage)

--- a/travis-opam.opam
+++ b/travis-opam.opam
@@ -16,15 +16,5 @@ build: [
 
 depends: [
   "jbuilder" {build}
-]
-
-depexts: [
-  [["alpine"] ["jq"]]
-  [["centos"] ["jq"]]
-  [["debian"] ["jq"]]
-  [["fedora"] ["jq"]]
-  [["homebrew" "osx"] ["jq"]]
-  [["opensuse"] ["jq"]]
-  [["oraclelinux"] ["jq"]]
-  [["ubuntu"] ["jq"]]
+  "jsonm" {build}
 ]


### PR DESCRIPTION
Fixes #208 

Sorry ```jsonm``` depends on ```uutf``` (which itself depends on uchar) so it seemed to me that copying 
the files here was too much.
The solution is then to depend on ```jsonm``` and to remove any installed dependencies after.
This solution also fixes the fact that ```jbuilder``` was installed but not remove so the script wouldn't have detected if there was a dependency missing.