### PR TITLE
Jsonm

### DIFF
--- a/src/ci_opam.ml
+++ b/src/ci_opam.ml
@@ -114,7 +114,7 @@ let json_of_src d =
   value (dec d) (fun v _ -> v) d
 
 let obj = function `O x -> x | _ -> assert false
-let arr = function `A x -> x | _ -> assert false
+let maybe_arr = function `A x -> x | _ -> []
 let str = function `String x -> x | _ -> assert false
 
 let get_package_versions_from_json file =
@@ -128,7 +128,7 @@ let get_package_versions_from_json file =
     in
     let get_install o = try get_pkg_ver (obj (List.assoc "install" o)) with Not_found -> [] in
     let get_pkg elt = get_install (obj elt) in
-    List.concat (List.map get_pkg (List.concat (List.map arr (arr (json_of_src decoder)))))
+    List.concat (List.map get_pkg (List.concat (List.map maybe_arr (maybe_arr (json_of_src decoder)))))
   in
   close_in file;
   pkgs

--- a/src/ci_opam.ml
+++ b/src/ci_opam.ml
@@ -121,15 +121,10 @@ let get_package_versions_from_json file =
   let file = open_in file in
   let decoder = Jsonm.decoder (`Channel file) in
   let pkgs =
-    let get_pkg_ver = function
-      | [] -> []
-      | o ->
-          let name = str (List.assoc "name" o) in
-          if String.equal name pkg_name then
-            []
-          else
-            let version = str (List.assoc "version" o) in
-            [name ^ "." ^ version]
+    let get_pkg_ver o =
+      let name = str (List.assoc "name" o) in
+      let version = str (List.assoc "version" o) in
+      if String.equal name pkg_name then [] else [name ^ "." ^ version]
     in
     let get_install o = try get_pkg_ver (obj (List.assoc "install" o)) with Not_found -> [] in
     let get_pkg elt = get_install (obj elt) in


### PR DESCRIPTION
cc @samoht 

Just a bit of cleanup and fix if the format given by ```opam install --json``` doesn't fit the required array json type. This is closer to what we got before (i.e. the jq query ```.[]?```)