### PR TITLE
Fix BASE_REMOTE in .travis-docker.sh in CentOS 7 containers

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -29,7 +29,7 @@ echo WORKDIR /home/opam/opam-repository >> Dockerfile
 
 if [ -n "$BASE_REMOTE" ]; then
     echo "RUN git remote set-url origin ${BASE_REMOTE} &&\
-        git fetch origin master && git reset --hard origin/master"  >> Dockerfile
+        git fetch origin && git reset --hard origin/master"  >> Dockerfile
 else
     echo RUN git pull origin master >> Dockerfile
 fi


### PR DESCRIPTION
When I specified a BASE_REMOTE that is completely separate from the
opam-repository, the older git version in the CentOS 7 container printed
a "no common commits" warning and failed to get the contents of the
master branch of the BASE_REMOTE.

I've fixed this by changing the fetch command to fetch the whole remote,
not just the master branch, this works in CentOS 7 too. This is probably
still more efficient for BASE_REMOTEs that are forks of opam-repository
than just deleting the directory and cloning BASE_REMOTE.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>