### PR TITLE
travis-docker: try to make git quieter

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -31,7 +31,7 @@ if [ -n "$BASE_REMOTE" ]; then
     echo "RUN git remote set-url origin ${BASE_REMOTE} &&\
         git fetch origin && git reset --hard origin/master"  >> Dockerfile
 else
-    echo RUN git pull origin master >> Dockerfile
+    echo RUN git pull -q origin master >> Dockerfile
 fi
 
 


### PR DESCRIPTION
Travis log was filling up with several thousand lines of, to me at least, uninteresting and uninformative `git` spew. This stops that...

(If the spew is actually useful, happy to make this another option; if so, what should the default be?)

Signed-off-by: Richard Mortier <mort@cantab.net>