### PR TITLE
Fix .travis-docker.sh when opam 2 is used

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -39,7 +39,9 @@ if [ -n "$BASE_REMOTE" ]; then
         git fetch origin && git reset --hard origin/master"  >> Dockerfile
 else
     case $opam_version in
-        2.0.0) echo RUN git pull -q origin 2.0.0 >> Dockerfile ;;
+        2.0.0)
+          echo RUN git checkout 2.0.0 >> Dockerfile
+          echo RUN git pull -q origin 2.0.0 >> Dockerfile ;;
         *) echo RUN git pull -q origin master >> Dockerfile ;;
     esac
 fi


### PR DESCRIPTION
Previously the git pull did not work, because the master branch was
checked out, and it failed to merge from the 2.0.0 branch. So make sure
we check out the 2.0.0 branch first before pulling.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>