### PR TITLE
RFC: Add support for BASE_REMOTE_BRANCH

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -6,11 +6,13 @@ default_user=ocaml
 default_branch=master
 default_hub_user=ocaml
 default_opam_version=2.0.0
+default_base_remote_branch=master
 
 fork_user=${FORK_USER:-$default_user}
 fork_branch=${FORK_BRANCH:-$default_branch}
 hub_user=${HUB_USER:-$default_hub_user}
 opam_version=${OPAM_VERSION:-$default_opam_version}
+base_remote_branch=${BASE_REMOTE_BRANCH:-$default_base_remote_branch}
 
 # create env file
 echo PACKAGE="$PACKAGE" > env.list
@@ -36,7 +38,7 @@ echo WORKDIR /home/opam/opam-repository >> Dockerfile
 
 if [ -n "$BASE_REMOTE" ]; then
     echo "RUN git remote set-url origin ${BASE_REMOTE} &&\
-        git fetch origin && git reset --hard origin/master"  >> Dockerfile
+        git fetch origin && git reset --hard origin/$base_remote_branch"  >> Dockerfile
 else
     case $opam_version in
         2.0.0)


### PR DESCRIPTION
So far, .travis-docker.sh uses branch "master" of any BASE_REMOTE that
is being supplied. This commit adds support to optionally use a
different branch which is supplied via BASE_REMOTE_BRANCH.

The motivation is to enable versioning of the Opam repository that is
being used. When such a repository is used to describe the universe of
packages for a product, it is natural to evolve it and the desire to
refer to a past status arises naturally.

Comparing this to .travis-ocaml.sh, it seem that it supports branches in the base remote already by using the syntax `git://github.com/ocaml/opam-repository#2.0.0`. It might be desirable to unify this.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>