### PR TITLE
Create a new switch if not pre-installed

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -55,7 +55,9 @@ if [ $fork_user != $default_user -o $fork_branch != $default_branch ]; then
 fi
 
 case $opam_version in
-    2.0.0) echo RUN opam switch ${OCAML_VERSION} >> Dockerfile ;;
+    2.0.0)
+      echo "RUN opam switch ${OCAML_VERSION} ||\
+          opam switch create ${OCAML_VERSION}" >> Dockerfile ;;
     *) ;;
 esac
 


### PR DESCRIPTION
This adds a fallback when `opam switch OCAML_VERSION` fails, attempting to create the corresponding switch, addressing #241.

This isn't perfect though since the pre-installed switches' names differ from the compiler names. One might wonder why their CI builds takes ages and have trouble figuring out it's because their `.travis.yml` contains
` - OCAML_VERSION=4.07.0` instead of `- OCAML_VERSION=4.07`.
Not sure what should be done to avoid this! 