### PR TITLE
use opam 2.0.1 by default

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -61,10 +61,10 @@ install_opam2 () {
             sudo add-apt-repository --yes ppa:ansible/bubblewrap
             sudo apt-get update -qq
             sudo apt-get install -y bubblewrap
-            sudo wget https://github.com/ocaml/opam/releases/download/2.0.0/opam-2.0.0-x86_64-linux -O /usr/local/bin/opam
+            sudo wget https://github.com/ocaml/opam/releases/download/2.0.1/opam-2.0.1-x86_64-linux -O /usr/local/bin/opam
             sudo chmod +x /usr/local/bin/opam ;;
         osx)
-            sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.0/opam-2.0.0-x86_64-darwin -o /usr/local/bin/opam
+            sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.1/opam-2.0.1-x86_64-darwin -o /usr/local/bin/opam
             sudo chmod +x /usr/local/bin/opam ;;
     esac
 }

--- a/README-travis.md
+++ b/README-travis.md
@@ -254,7 +254,7 @@ Configuration choices are passed to `mirage configure` via environment variables
 
 ### Changing the version of opam
 
-By default, the CI scripts are using the latest RC release of opam *2.0.0*.
+By default, the CI scripts are using the latest release of opam *2.0.1*.
 To use a different version of opam, use:
 
 ```yaml


### PR DESCRIPTION
as suggested in https://github.com/ocaml/opam/issues/3548#issuecomment-431651465

it is unclear to me how the version numbering should work here:
- should there be a OPAM=2 which sticks to the latest release of opam (within major version 2)? (and/or OPAM=2.0 to specify the 2.0.X release series?)
- is there any need to specify exact versions (i.e. opam2.0.0, opam2.0.1)?
- when to phase out opam1 (1.1.2, 1.2.0, 1.2.2) support?