### PR TITLE
Ensure the Travis opam init selects the compiler unambiguously

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -256,7 +256,7 @@ case $TRAVIS_OS_NAME in
     linux) install_on_linux ;;
 esac
 
-OPAM_SWITCH=${OPAM_SWITCH:-$OCAML_FULL_VERSION}
+OPAM_SWITCH=${OPAM_SWITCH:-ocaml-base-compiler.$OCAML_FULL_VERSION}
 
 export OPAMYES=1
 


### PR DESCRIPTION
This [fixes](https://travis-ci.org/Chris00/ocaml-odepack/jobs/447836933#L742)  [issue 259](https://github.com/ocaml/ocaml-ci-scripts/issues/259).