### PR TITLE
Fix travis-docker when using opam 1.2

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -45,6 +45,7 @@ else
           echo RUN git checkout master >> Dockerfile
           echo RUN git pull -q origin master >> Dockerfile ;;
         *)
+          echo RUN git fetch -q origin 1.2 >> Dockerfile
           echo RUN git checkout 1.2 >> Dockerfile
           echo RUN git pull -q origin 1.2 >> Dockerfile ;;
     esac


### PR DESCRIPTION
The `1.2` does not exist locally in the container so `git checkout 1.2` fails. This PR fixes this by fetching the branch from origin first.