### PR TITLE
ocaml-config issue workaround

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -50,7 +50,7 @@ else
           echo RUN git pull -q origin 1.2 >> Dockerfile ;;
     esac
 fi
-
+echo RUN opam update >> Dockerfile
 
 echo RUN opam remove travis-opam >> Dockerfile
 if [ $fork_user != $default_user -o $fork_branch != $default_branch ]; then
@@ -66,7 +66,7 @@ case $opam_version in
     *) ;;
 esac
 
-echo RUN opam update -u -y >> Dockerfile
+echo RUN opam upgrade -y >> Dockerfile
 # Temporarily install opam-ed to work around https://github.com/ocaml/opam/issues/3662
 echo RUN opam depext -ui travis-opam opam-ed >> Dockerfile
 echo RUN cp '~/.opam/$(opam switch show)/bin/ci-opam' "~/" >> Dockerfile


### PR DESCRIPTION
Workaround for https://github.com/ocaml/opam-repository/issues/12936

The workaround should work by having the base packages all upgraded first and not having to upgrade them upon `opam remove -a` which seems to cause the issue.

cc @dra27 @samoht 

cc @c-cube @mseri would you like to test with this version of the `.travis-docker.sh` script? Should just need to replace the original script link by this one: https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/9c602f881f2b55649011e37002f9177cbf9af8b2/.travis-docker.sh