### PR TITLE
Workaround opam remove -a problems

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -67,9 +67,16 @@ case $opam_version in
 esac
 
 echo RUN opam update -u -y >> Dockerfile
-echo RUN opam depext -ui travis-opam >> Dockerfile
+# Temporarily install opam-ed to work around https://github.com/ocaml/opam/issues/3662
+echo RUN opam depext -ui travis-opam opam-ed >> Dockerfile
 echo RUN cp '~/.opam/$(opam switch show)/bin/ci-opam' "~/" >> Dockerfile
-echo RUN opam remove -a travis-opam >> Dockerfile
+# Ensure that ocaml-config.1 is definitely in the compiler (base) packages
+# for the switch. The remove-item is to ensure that it only appears once.
+echo RUN opam exec -- opam-ed -i -f '~/.opam/$(opam switch show)/.opam-switch/switch-state' \
+                              "'remove-item compiler \"ocaml-config.1\"'" \
+                              "'append compiler \"ocaml-config.1\"'" >> Dockerfile
+# opam should now not attempt to remove ocaml-config.1
+echo RUN opam remove -a travis-opam opam-ed >> Dockerfile
 echo RUN mv "~/ci-opam" '~/.opam/$(opam switch show)/bin/ci-opam' >> Dockerfile
 echo VOLUME /repo >> Dockerfile
 echo WORKDIR /repo >> Dockerfile


### PR DESCRIPTION
Another piece in the puzzle for https://github.com/ocaml/opam/issues/3662 - #267 ensures that newly built compilers in the container will install correctly by putting `ocaml-config.1` in the switch base packages where it belongs. That only works if you specify a full compiler to install (e.g. 4.05.0) - if the switch in the container (e.g. 4.05) is used, then hoisting the `opam update` doesn't help.

This temporary patch installs `opam-ed` and uses it to edit the `switch-state` file after the update/upgrade to ensure that `ocaml-config.1` is definitely in the base packages.

https://github.com/ocaml/opam/pull/3666 fixes this permanently - once that's deployed, this commit should be reverted.