### PR TITLE
No longer need opam switch set-base workaround with opam 2.0.2

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -94,8 +94,6 @@ esac
 echo RUN opam upgrade -y >> Dockerfile
 echo RUN opam depext -ui travis-opam >> Dockerfile
 echo RUN cp '~/.opam/$(opam switch show)/bin/ci-opam' "~/" >> Dockerfile
-# Ensure that ocaml-config is definitely in the compiler (base) packages
-echo RUN opam switch set-base '$(opam list --base --short | grep -Fxv ocaml-config | tr "\n" " " | sed -e "s/$/ocaml-config/")' >> Dockerfile
 echo RUN opam remove -a travis-opam >> Dockerfile
 echo RUN mv "~/ci-opam" '~/.opam/$(opam switch show)/bin/ci-opam' >> Dockerfile
 echo VOLUME /repo >> Dockerfile


### PR DESCRIPTION
This reverts commit 5a9e2983ebc494aef6dc85e5e53fd10087525dd6 and is here as a reminder for when opam 2.0.2 arrives - it can be merged once the containers on ocaml/opam2 are upgraded to 2.0.2