### PR TITLE
verbose install to keep CI alive

### DIFF
--- a/src/ci_opam.ml
+++ b/src/ci_opam.ml
@@ -281,7 +281,7 @@ with_fold "Prepare" (fun () ->
 
 with_fold "Simple" (fun () ->
     (* Install the OCaml dependencies *)
-    ?|~ "opam install %s --deps-only" pkg;
+    ?|~ "opam install %s --deps-only -v" pkg;
 
     (* Simple installation/removal test *)
     if install_run then (


### PR DESCRIPTION
Dependencies like Coq take a long time to install.