### PR TITLE
Simpler fix for opam remove -a

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -92,16 +92,9 @@ case $opam_version in
 esac
 
 echo RUN opam upgrade -y >> Dockerfile
-# Temporarily install opam-ed to work around https://github.com/ocaml/opam/issues/3662
-echo RUN opam depext -ui travis-opam opam-ed >> Dockerfile
+echo RUN opam depext -ui travis-opam >> Dockerfile
 echo RUN cp '~/.opam/$(opam switch show)/bin/ci-opam' "~/" >> Dockerfile
-# Ensure that ocaml-config.1 is definitely in the compiler (base) packages
-# for the switch. The remove-item is to ensure that it only appears once.
-echo RUN opam exec -- opam-ed -i -f '~/.opam/$(opam switch show)/.opam-switch/switch-state' \
-                              "'remove-item compiler \"ocaml-config.1\"'" \
-                              "'append compiler \"ocaml-config.1\"'" >> Dockerfile
-# opam should now not attempt to remove ocaml-config.1
-echo RUN opam remove -a travis-opam opam-ed >> Dockerfile
+echo RUN opam remove -a travis-opam >> Dockerfile
 echo RUN mv "~/ci-opam" '~/.opam/$(opam switch show)/bin/ci-opam' >> Dockerfile
 echo VOLUME /repo >> Dockerfile
 echo WORKDIR /repo >> Dockerfile

--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -94,6 +94,8 @@ esac
 echo RUN opam upgrade -y >> Dockerfile
 echo RUN opam depext -ui travis-opam >> Dockerfile
 echo RUN cp '~/.opam/$(opam switch show)/bin/ci-opam' "~/" >> Dockerfile
+# Ensure that ocaml-config is definitely in the compiler (base) packages
+echo RUN opam switch set-base '$(opam list --base --short | grep -Fxv ocaml-config | tr "\n" " " | sed -e "s/$/ocaml-config/")' >> Dockerfile
 echo RUN opam remove -a travis-opam >> Dockerfile
 echo RUN mv "~/ci-opam" '~/.opam/$(opam switch show)/bin/ci-opam' >> Dockerfile
 echo VOLUME /repo >> Dockerfile


### PR DESCRIPTION
@rjbou pointed out that I'd missed `opam switch set-base`. Here is a simpler solution than #268.