### PR TITLE
Update APT before querying apt-cache

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -121,6 +121,8 @@ install_opam2 () {
 install_ppa () {
   add_ppa $1
   if [ "${INSTALL_LOCAL:=0}" = 0 ] ; then
+    sudo apt-get -qq update
+    APT_UPDATED=1
     apt_install \
        "$(full_apt_version ocaml $SYS_OCAML_VERSION)" \
        "$(full_apt_version ocaml-base $SYS_OCAML_VERSION)" \


### PR DESCRIPTION
This fixes a regression introduced in df00917752 concerning the `install_ppa` function in `.travis-ocaml.sh`:

`install_ppa` first calls `add_ppa` but not `apt-get update`. It then calls `full_apt_version` (for the arguments of `apt_install`), which fails to see the version from the PPA.

See https://travis-ci.org/thpani/coachman/builds/458377031 for a failing travis build.