### PR TITLE
Fix .travis-ocaml.sh on trusty when installing OCaml 4.01

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -154,8 +154,6 @@ install_on_linux () {
         install_ppa avsm/ocaml42+opam12 ;;
     4.01,2*)
         OCAML_FULL_VERSION=4.01.0
-        OPAM_SWITCH=${OPAM_SWITCH:-ocaml-system}
-        install_ocaml
         install_opam2 ;;
     4.02,1.1.2)
         OCAML_FULL_VERSION=4.02.3


### PR DESCRIPTION
Travis has now support for Ubuntu trusty (and now use it for opam-repository CI) and in this version, OCaml 4.01 is not the version of OCaml that is available but rather OCaml 4.02 is. So when trying to install OCaml 4.01 the script will rather install OCaml 4.02 instead.

This PR fixes that by not installing the system compiler for 4.01