### PR TITLE
Do not install system camlp4

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -95,8 +95,7 @@ apt_install () {
 install_ocaml () {
     apt_install \
          ocaml ocaml-base ocaml-native-compilers ocaml-compiler-libs \
-         ocaml-interp ocaml-base-nox ocaml-nox \
-         camlp4 camlp4-extra
+         ocaml-interp ocaml-base-nox ocaml-nox
 }
 
 install_opam2 () {
@@ -130,9 +129,7 @@ install_ppa () {
        "$(full_apt_version ocaml-compiler-libs $SYS_OCAML_VERSION)" \
        "$(full_apt_version ocaml-interp $SYS_OCAML_VERSION)" \
        "$(full_apt_version ocaml-base-nox $SYS_OCAML_VERSION)" \
-       "$(full_apt_version ocaml-nox $SYS_OCAML_VERSION)" \
-       "$(full_apt_version camlp4 $SYS_OCAML_VERSION)" \
-       "$(full_apt_version camlp4-extra $SYS_OCAML_VERSION)"
+       "$(full_apt_version ocaml-nox $SYS_OCAML_VERSION)"
   fi
   apt_install opam
 }

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -88,7 +88,7 @@ apt_install () {
             APT_UPDATED=1
             sudo apt-get update -qq
         fi
-        sudo apt-get install -y "$@"
+        sudo apt-get install --no-install-recommends -y "$@"
     fi
 }
 


### PR DESCRIPTION
I am not sure why it needs to be installed with apt?
But now it causes some real problem, see https://github.com/ocaml/opam-repository/pull/13713#issuecomment-475270065
Making sure camlp4 is installed only through opam fixes it, see https://travis-ci.org/ahrefs/devkit/builds/510055472