### PR TITLE
Add the project name to dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 1.0)
+(name travis-opam)


### PR DESCRIPTION
Avoids such errors: https://travis-ci.org/Chris00/ocaml-crlibm/jobs/516533307#L751 making all CI build fail.