### PR TITLE
Allow to check formatting for travis docker builds

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -16,6 +16,10 @@ hub_user=${HUB_USER:-$default_hub_user}
 opam_version=${OPAM_VERSION:-$default_opam_version}
 base_remote_branch=${BASE_REMOTE_BRANCH:-$default_base_remote_branch}
 
+[ -z "$OCAMLFORMAT" ] && [ -z "$OCAML_VERSION" ] \
+  && echo "You need to set at least one of OCAMLFORMAT or OCAML_VERSION env variables" \
+  && exit 1
+
 if [ ! -z "$OCAMLFORMAT" ]; then
   from=${hub_user}/ocamlformat:${OCAMLFORMAT}
 

--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -15,103 +15,116 @@ hub_user=${HUB_USER:-$default_hub_user}
 opam_version=${OPAM_VERSION:-$default_opam_version}
 base_remote_branch=${BASE_REMOTE_BRANCH:-$default_base_remote_branch}
 
-# create env file
-echo PACKAGE="$PACKAGE" > env.list
-echo EXTRA_REMOTES="$EXTRA_REMOTES" >> env.list
-echo PINS="$PINS" >> env.list
-echo INSTALL="$INSTALL" >> env.list
-echo DEPOPTS="$DEPOPTS" >> env.list
-echo TESTS="$TESTS" >> env.list
-echo REVDEPS="$REVDEPS" >> env.list
-echo EXTRA_DEPS="$EXTRA_DEPS" >> env.list
-echo PRE_INSTALL_HOOK="$PRE_INSTALL_HOOK" >> env.list
-echo POST_INSTALL_HOOK="$POST_INSTALL_HOOK" >> env.list
-echo $EXTRA_ENV >> env.list
+if [ ! -z "$OCAMLFORMAT" ]; then
+  from=${hub_user}/ocamlformat:${OCAMLFORMAT}
 
-# build a local image to trigger any ONBUILDs
-case $opam_version in
-    2*)
-        if [ "$opam_version" != "2" ] ; then
-          set +x
-          # There is no way to tell Travis to close a fold but have it initially
-          # open.
-          echo -en "travis_fold:end:$fold_name.ci\r"
-          echo -e "[\e[0;31mWARNING\e[0m] Ignored OPAM_VERSION=$OPAM_VERSION; interpreted as \"2\"" >&2
-          echo -e "[\e[0;31mWARNING\e[0m] The containers have the latest maintenance release of opam 2.0" >&2
-          opam_version=2
-          echo -en "travis_fold:start:continue.ci\r"
-          fold_name="continue"
-          set -x
-        fi
-        from=${hub_user}/opam2:${DISTRO} ;;
-    *)
-        if [ "$opam_version" != "1" ] ; then
-          set +x
-          echo -en "travis_fold:end:$fold_name.ci\r"
-          echo -e "[\e[0;31mWARNING\e[0m] Ignored OPAM_VERSION=$OPAM_VERSION; interpreted as \"1\"" >&2
-          echo -e "[\e[0;31mWARNING\e[0m] The containers all run OPAM 1.2.2" >&2
-          echo -en "travis_fold:start:continue.ci\r"
-          fold_name="continue"
-          opam_version=1
-          set -x
-        fi
-        from=${hub_user}/opam:${DISTRO}_ocaml-${OCAML_VERSION} ;;
-esac
+  echo FROM $from > ocamlformat.dockerfile
+  echo COPY . . >> ocamlformat.dockerfile
+  echo RUN sudo chown -R opam /home/opam/src >> ocamlformat.dockerfile
+  echo RUN opam exec dune build @fmt >> ocamlformat.dockerfile
 
-echo FROM $from  > Dockerfile
-echo WORKDIR /home/opam/opam-repository >> Dockerfile
-
-if [ -n "$BASE_REMOTE" ]; then
-    echo "RUN git remote set-url origin ${BASE_REMOTE} &&\
-        git fetch origin && git reset --hard origin/$base_remote_branch"  >> Dockerfile
-else
-    case $opam_version in
-        2)
-          echo RUN git checkout master >> Dockerfile
-          echo RUN git pull -q origin master >> Dockerfile ;;
-        *)
-          echo RUN git fetch -q origin 1.2 >> Dockerfile
-          echo RUN git checkout 1.2 >> Dockerfile
-          echo RUN git pull -q origin 1.2 >> Dockerfile ;;
-    esac
-fi
-echo RUN opam update >> Dockerfile
-
-echo RUN opam remove travis-opam >> Dockerfile
-if [ $fork_user != $default_user -o $fork_branch != $default_branch ]; then
-    echo RUN opam pin add -n travis-opam \
-         https://github.com/$fork_user/ocaml-ci-scripts.git#$fork_branch \
-         >> Dockerfile
+  docker build -f ocamlformat.dockerfile .
 fi
 
-case $opam_version in
-    2)
-      echo "RUN opam switch ${OCAML_VERSION} ||\
-          opam switch create ocaml-base-compiler.${OCAML_VERSION}" >> Dockerfile ;;
-    *) ;;
-esac
+if [ ! -z "$OCAML_VERSION" ]; then
+  # create env file
+  echo PACKAGE="$PACKAGE" > env.list
+  echo EXTRA_REMOTES="$EXTRA_REMOTES" >> env.list
+  echo PINS="$PINS" >> env.list
+  echo INSTALL="$INSTALL" >> env.list
+  echo DEPOPTS="$DEPOPTS" >> env.list
+  echo TESTS="$TESTS" >> env.list
+  echo REVDEPS="$REVDEPS" >> env.list
+  echo EXTRA_DEPS="$EXTRA_DEPS" >> env.list
+  echo PRE_INSTALL_HOOK="$PRE_INSTALL_HOOK" >> env.list
+  echo POST_INSTALL_HOOK="$POST_INSTALL_HOOK" >> env.list
+  echo $EXTRA_ENV >> env.list
 
-echo RUN opam upgrade -y >> Dockerfile
-echo RUN opam depext -ui travis-opam >> Dockerfile
-echo RUN cp '~/.opam/$(opam switch show)/bin/ci-opam' "~/" >> Dockerfile
-# Ensure that ocaml-config is definitely in the compiler (base) packages
-echo RUN opam switch set-base '$(opam list --base --short | grep -Fxv ocaml-config | tr "\n" " " | sed -e "s/$/ocaml-config/")' >> Dockerfile
-echo RUN opam remove -a travis-opam >> Dockerfile
-echo RUN mv "~/ci-opam" '~/.opam/$(opam switch show)/bin/ci-opam' >> Dockerfile
-echo VOLUME /repo >> Dockerfile
-echo WORKDIR /repo >> Dockerfile
+  # build a local image to trigger any ONBUILDs
+  case $opam_version in
+      2*)
+          if [ "$opam_version" != "2" ] ; then
+            set +x
+            # There is no way to tell Travis to close a fold but have it initially
+            # open.
+            echo -en "travis_fold:end:$fold_name.ci\r"
+            echo -e "[\e[0;31mWARNING\e[0m] Ignored OPAM_VERSION=$OPAM_VERSION; interpreted as \"2\"" >&2
+            echo -e "[\e[0;31mWARNING\e[0m] The containers have the latest maintenance release of opam 2.0" >&2
+            opam_version=2
+            echo -en "travis_fold:start:continue.ci\r"
+            fold_name="continue"
+            set -x
+          fi
+          from=${hub_user}/opam2:${DISTRO} ;;
+      *)
+          if [ "$opam_version" != "1" ] ; then
+            set +x
+            echo -en "travis_fold:end:$fold_name.ci\r"
+            echo -e "[\e[0;31mWARNING\e[0m] Ignored OPAM_VERSION=$OPAM_VERSION; interpreted as \"1\"" >&2
+            echo -e "[\e[0;31mWARNING\e[0m] The containers all run OPAM 1.2.2" >&2
+            echo -en "travis_fold:start:continue.ci\r"
+            fold_name="continue"
+            opam_version=1
+            set -x
+          fi
+          from=${hub_user}/opam:${DISTRO}_ocaml-${OCAML_VERSION} ;;
+  esac
 
-docker build -t local-build .
+  echo FROM $from  > Dockerfile
+  echo WORKDIR /home/opam/opam-repository >> Dockerfile
 
-echo Dockerfile:
-cat Dockerfile
-echo env.list:
-cat env.list
-echo Command:
-OS=~/build/$TRAVIS_REPO_SLUG
-echo docker run --env-file=env.list -v ${OS}:/repo local-build ci-opam
+  if [ -n "$BASE_REMOTE" ]; then
+      echo "RUN git remote set-url origin ${BASE_REMOTE} &&\
+          git fetch origin && git reset --hard origin/$base_remote_branch"  >> Dockerfile
+  else
+      case $opam_version in
+          2)
+            echo RUN git checkout master >> Dockerfile
+            echo RUN git pull -q origin master >> Dockerfile ;;
+          *)
+            echo RUN git fetch -q origin 1.2 >> Dockerfile
+            echo RUN git checkout 1.2 >> Dockerfile
+            echo RUN git pull -q origin 1.2 >> Dockerfile ;;
+      esac
+  fi
+  echo RUN opam update >> Dockerfile
 
-# run ci-opam with the local repo volume mounted
-chmod -R a+w $OS
-echo -en "travis_fold:end:$fold_name.ci\r"
-docker run --env-file=env.list -v ${OS}:/repo local-build ci-opam
+  echo RUN opam remove travis-opam >> Dockerfile
+  if [ $fork_user != $default_user -o $fork_branch != $default_branch ]; then
+      echo RUN opam pin add -n travis-opam \
+           https://github.com/$fork_user/ocaml-ci-scripts.git#$fork_branch \
+           >> Dockerfile
+  fi
+
+  case $opam_version in
+      2)
+        echo "RUN opam switch ${OCAML_VERSION} ||\
+            opam switch create ocaml-base-compiler.${OCAML_VERSION}" >> Dockerfile ;;
+      *) ;;
+  esac
+
+  echo RUN opam upgrade -y >> Dockerfile
+  echo RUN opam depext -ui travis-opam >> Dockerfile
+  echo RUN cp '~/.opam/$(opam switch show)/bin/ci-opam' "~/" >> Dockerfile
+  # Ensure that ocaml-config is definitely in the compiler (base) packages
+  echo RUN opam switch set-base '$(opam list --base --short | grep -Fxv ocaml-config | tr "\n" " " | sed -e "s/$/ocaml-config/")' >> Dockerfile
+  echo RUN opam remove -a travis-opam >> Dockerfile
+  echo RUN mv "~/ci-opam" '~/.opam/$(opam switch show)/bin/ci-opam' >> Dockerfile
+  echo VOLUME /repo >> Dockerfile
+  echo WORKDIR /repo >> Dockerfile
+
+  docker build -t local-build .
+
+  echo Dockerfile:
+  cat Dockerfile
+  echo env.list:
+  cat env.list
+  echo Command:
+  OS=~/build/$TRAVIS_REPO_SLUG
+  echo docker run --env-file=env.list -v ${OS}:/repo local-build ci-opam
+
+  # run ci-opam with the local repo volume mounted
+  chmod -R a+w $OS
+  echo -en "travis_fold:end:$fold_name.ci\r"
+  docker run --env-file=env.list -v ${OS}:/repo local-build ci-opam
+fi

--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -1,5 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
 # To use this, run `opam travis --help`
+set -e
 
 fold_name="prepare"
 echo -en "travis_fold:start:$fold_name.ci\r"

--- a/README-travis.md
+++ b/README-travis.md
@@ -218,6 +218,30 @@ repository, `.travis-opam.sh` users can layer additional opam remotes on top
 of the `BASE_REMOTE` with `EXTRA_REMOTES`. Remotes are added from left
 to right.
 
+## Docker builds, `.travis-docker.sh`
+
+### Check code formatting
+
+You can check the formatting of your `dune` and OCaml files by setting the `OCAMLFORMAT` env
+variable to the `ocamlformat` version you're using to format your code.
+
+Note that this only works if your project uses `dune` as build system and you enabled the formatting
+with a `(using fmt <ver>)` field in your `dune-project`.
+
+Note that the formatting check is performed separately and independently from the main build. It's
+done using an image with the pre-installed ocamlformat version on a switch with the latest version
+of OCaml and doesn't install anything nor try to build your packages. It just runs `dune build @fmt`
+to verify that the code is correctly formatted. It will fail and print the diff if it's not.
+
+That means that you can run it as a seperate build, e.g. you can do:
+
+```yaml
+env:
+  - OCAML_VERSION=4.06
+  - OCAML_VERSION=4.07
+  - OCAMLFORMAT=0.9
+```
+
 ## GCC and binutils
 
 ```yaml


### PR DESCRIPTION
This PR allows `.travis-docker.sh` users to check the formatting of their `dune` and OCaml files use the `dune`'s `@fmt` target by setting the `OCAMLFORMAT` env variable to the `ocamlformat` version they wish to use.

Currently this is ran as a separate build which means you can do:
```yaml
env:
  - OCAML_VERSION=4.06
  - OCAML_VERSION=4.07
  - OCAMLFORMAT=0.9
```

When the `OCAMLFORMAT` env variable is set, a separate `docker build` is executed. It uses a base image with pre-installed `dune` and `ocamlformat`. I added such images to my personal docker hub for `0.7`, `0.8` and `0.9` but such images should be added to the `ocaml` hub if we wish to get this merged.

I tested the new script in this draft PR: https://github.com/mirage/fiat/pull/33

You can have a look at the build output for a badly formatted repo [here](https://github.com/mirage/fiat/pull/33) and a successful build [here](https://travis-ci.com/NathanReb/fiat/jobs/198903197).

It also comes with a couple small fixes in separate commits.

Let me know what you think!