### PR TITLE
Fix opam BASE_REMOTE problems

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -62,8 +62,7 @@ echo FROM $from  > Dockerfile
 echo WORKDIR /home/opam/opam-repository >> Dockerfile
 
 if [ -n "$BASE_REMOTE" ]; then
-    echo "RUN git remote set-url origin ${BASE_REMOTE} &&\
-        git fetch origin && git reset --hard origin/$base_remote_branch"  >> Dockerfile
+    echo "RUN opam repo remove --all default && opam repo add --all-switches default ${BASE_REMOTE}#${base_remote_branch}" >> Dockerfile
 else
     case $opam_version in
         2)
@@ -75,7 +74,7 @@ else
           echo RUN git pull -q origin 1.2 >> Dockerfile ;;
     esac
 fi
-echo RUN opam update >> Dockerfile
+echo RUN opam update --verbose >> Dockerfile
 
 echo RUN opam remove travis-opam >> Dockerfile
 if [ $fork_user != $default_user -o $fork_branch != $default_branch ]; then


### PR DESCRIPTION
Travis started to fail today with (https://travis-ci.org/xapi-project/xcp-idl/builds/547278042?utm_source=github_status&utm_medium=notification):
```
[ERROR] Could not update repository "default": "/usr/bin/patch -p1 -i /home/opam/.opam/log/processed-patch-7-58c514" exited with code 1
```

Running locally with `opam update --debug` shows that this is happening:
```
00:00.148  PARALLEL                        Collected task for job 0 (ret:0)
00:00.149  PARALLEL                        Next task in job 0: /usr/bin/git fetch -q file:///home/opam/opam-repository --update-shallow +HEAD:refs/remotes/opam-ref
00:01.199  PARALLEL                        Collected task for job 0 (ret:0)
00:01.202  PARALLEL                        Next task in job 0: /usr/bin/git add .
00:02.968  PARALLEL                        Collected task for job 0 (ret:0)
00:02.971  PARALLEL                        Next task in job 0: /usr/bin/git -c diff.noprefix=false diff --no-ext-diff -R -p refs/remotes/opam-ref --
00:04.061  PARALLEL                        Collected task for job 0 (ret:0)
00:04.061  REPOSITORY                      default: applying patch update at /home/opam/.opam/log/git-diff-8-ccabea
[default] synchronised from git+file:///home/opam/opam-repository
00:04.558  SYSTEM                          [log-8-ffb3fd] (in 0.016s) cp /home/opam/.opam/log/git-diff-8-ccabea /home/opam/.opam/log/processed-patch-8-58c514
00:04.564  PARALLEL                        Next task in job 0: /usr/bin/patch -p1 -i /home/opam/.opam/log/processed-patch-8-58c514
```

There are no common commits between the 2 remotes, so this essentially tries to build a huge patch to transform one git repository into a completely different one, which takes a long time and prone to failure.

Instead we should simply remove the default repo URL and add the new repo URL, which is a lot faster and should fix this problem.