### PR TITLE
Don't write unset variables to env.list in Docker script

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -16,16 +16,17 @@ opam_version=${OPAM_VERSION:-$default_opam_version}
 base_remote_branch=${BASE_REMOTE_BRANCH:-$default_base_remote_branch}
 
 # create env file
-echo PACKAGE="$PACKAGE" > env.list
-echo EXTRA_REMOTES="$EXTRA_REMOTES" >> env.list
-echo PINS="$PINS" >> env.list
-echo INSTALL="$INSTALL" >> env.list
-echo DEPOPTS="$DEPOPTS" >> env.list
-echo TESTS="$TESTS" >> env.list
-echo REVDEPS="$REVDEPS" >> env.list
-echo EXTRA_DEPS="$EXTRA_DEPS" >> env.list
-echo PRE_INSTALL_HOOK="$PRE_INSTALL_HOOK" >> env.list
-echo POST_INSTALL_HOOK="$POST_INSTALL_HOOK" >> env.list
+rm -f env.list
+if [ -n "${PACKAGE+x}" ] ; then echo PACKAGE="$PACKAGE" >> env.list ; fi
+if [ -n "${EXTRA_REMOTES+x}" ] ; then echo EXTRA_REMOTES="$EXTRA_REMOTES" >> env.list ; fi
+if [ -n "${PINS+x}" ] ; then echo PINS="$PINS" >> env.list ; fi
+if [ -n "${INSTALL+x}" ] ; then echo INSTALL="$INSTALL" >> env.list ; fi
+if [ -n "${DEPOPTS+x}" ] ; then echo DEPOPTS="$DEPOPTS" >> env.list ; fi
+if [ -n "${TESTS+x}" ] ; then echo TESTS="$TESTS" >> env.list ; fi
+if [ -n "${REVDEPS+x}" ] ; then echo REVDEPS="$REVDEPS" >> env.list ; fi
+if [ -n "${EXTRA_DEPS+x}" ] ; then echo EXTRA_DEPS="$EXTRA_DEPS" >> env.list ; fi
+if [ -n "${PRE_INSTALL_HOOK+x}" ] ; then echo PRE_INSTALL_HOOK="$PRE_INSTALL_HOOK" >> env.list ; fi
+if [ -n "${POST_INSTALL_HOOK+x}" ] ; then echo POST_INSTALL_HOOK="$POST_INSTALL_HOOK" >> env.list ; fi
 echo $EXTRA_ENV >> env.list
 
 # build a local image to trigger any ONBUILDs

--- a/src/ci_opam.ml
+++ b/src/ci_opam.ml
@@ -26,6 +26,7 @@ let default_pkg = "my-package"
 
 let pkg =
   let pkg = getenv_default "PACKAGE" default_pkg in
+  let pkg = if String.length pkg = 0 then default_pkg else pkg in
   if pkg <> default_pkg then pkg
   else
     let files = Array.to_list (Sys.readdir ".") in


### PR DESCRIPTION
Writing `PACKAGE=` to `env.list` means that `PACKAGE` is the empty string, rather than unset. This causes [confusing error messages](https://travis-ci.org/avsm/ocaml-dockerfile/jobs/550130401#L693)

cc @avsm