### PR TITLE
Remove jbuilder remnants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:alpine as base
 
-RUN opam depext -iy jbuilder
+RUN opam depext -iy dune
 
 COPY . /home/opam/src/travis-opam
 RUN sudo chown opam.nogroup -R /home/opam/src/travis-opam
@@ -8,7 +8,7 @@ RUN sudo chown opam.nogroup -R /home/opam/src/travis-opam
 WORKDIR /home/opam/src/travis-opam
 
 RUN sed -i "s/^;\(.*static.*\)$/\1/" src/jbuild
-RUN opam config exec -- jbuilder build
+RUN opam config exec -- dune build
 RUN sudo cp /home/opam/src/travis-opam/_build/default/src/ci_opam.exe /usr/bin/ci-opam
 
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: all clean
 
 all:
-	jbuilder build --dev
+	dune build --dev
 
 clean:
-	jbuilder clean
+	dune clean
 
 push:
 	docker build . -t ocaml/ci-opam


### PR DESCRIPTION
Well, now it is deprecated, time to remove it. Not sure what to do with `pkg/pkg.ml` though...