### PR TITLE
Update latest OCaml 4.08 version

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -216,10 +216,10 @@ install_on_linux () {
         OCAML_FULL_VERSION=4.07.1
         install_opam2 ;;
     4.08,1.2.2)
-        OCAML_FULL_VERSION=4.08.0
+        OCAML_FULL_VERSION=4.08.1
         install_ppa avsm/ocaml42+opam12 ;;
     4.08,2*)
-        OCAML_FULL_VERSION=4.08.0
+        OCAML_FULL_VERSION=4.08.1
         install_opam2 ;;
     *) echo "Unknown OCAML_VERSION=$OCAML_VERSION OPAM_VERSION=$OPAM_VERSION"
        echo "(An unset OCAML_VERSION used to default to \"latest\", but you must now specify it."
@@ -288,11 +288,11 @@ install_on_osx () {
     4.06,2*) OCAML_FULL_VERSION=4.06.1; install_opam2 ;;
     4.07,1.2.2) OCAML_FULL_VERSION=4.07.1; brew install opam ;;
     4.07,2*) OCAML_FULL_VERSION=4.07.1; install_opam2 ;;
-    4.08,1.2.2) OCAML_FULL_VERSION=4.08.0;
+    4.08,1.2.2) OCAML_FULL_VERSION=4.08.1;
                 OPAM_SWITCH=${OPAM_SWITCH:-system};
                 brew install ocaml;
                 brew install opam ;;
-    4.08,2*) OCAML_FULL_VERSION=4.08.0;
+    4.08,2*) OCAML_FULL_VERSION=4.08.1;
                 OPAM_SWITCH=${OPAM_SWITCH:-ocaml-system};
                 brew install ocaml;
                 install_opam2 ;;


### PR DESCRIPTION
Since OCaml 4.08.1 has been released a few weeks ago, ocaml-ci-scripts needs to be updated to provide the latest version available.