### PR TITLE
Travis-docker: Allow non-standard (e.g. ocaml-variants) switches to be created

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -87,7 +87,8 @@ fi
 case $opam_version in
     2)
       echo "RUN opam switch ${OCAML_VERSION} ||\
-          opam switch create ocaml-base-compiler.${OCAML_VERSION}" >> Dockerfile ;;
+          opam switch create ocaml-base-compiler.${OCAML_VERSION} ||\
+          opam switch create ${OCAML_VERSION}" >> Dockerfile ;;
     *) ;;
 esac
 


### PR DESCRIPTION
This PR allows to test switches such as `ocaml-variants.4.10.0+trunk` in Travis CI