### PR TITLE
Travis-docker: Add a config variable to enable ocaml-beta

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -17,11 +17,7 @@ opam_version=${OPAM_VERSION:-$default_opam_version}
 base_remote_branch=${BASE_REMOTE_BRANCH:-$default_base_remote_branch}
 
 if [ "$OCAML_BETA" = "enable" ]; then
-    if [ -z "${EXTRA_REMOTES}" ]; then
-        EXTRA_REMOTES="$beta_repository"
-    else
-        EXTRA_REMOTES="${EXTRA_REMOTES} $beta_repository"
-    fi
+    EXTRA_REMOTES="${EXTRA_REMOTES}${EXTRA_REMOTES:+ }$beta_repository"
 fi
 
 # create env file
@@ -95,14 +91,15 @@ fi
 
 case $opam_version in
     2)
-      opam_switch_selection=
+      opam_repo_selection=
+      ocaml_package=ocaml-base-compiler
       if [ "$OCAML_BETA" = "enable" ]; then
           echo "RUN opam repo add --dont-select beta $beta_repository" >> Dockerfile
-          opam_switch_selection="--repo=default,beta "
+          opam_repo_selection="--repo=default,beta "
+          ocaml_package=ocaml-variants
       fi
       echo "RUN opam switch ${OCAML_VERSION} ||\
-          opam switch create ${opam_switch_selection}ocaml-base-compiler.${OCAML_VERSION} ||\
-          opam switch create ${opam_switch_selection}${OCAML_VERSION}" >> Dockerfile ;;
+          opam switch create ${opam_repo_selection}${ocaml_package}.${OCAML_VERSION}" >> Dockerfile ;;
     *) ;;
 esac
 

--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -8,12 +8,21 @@ default_branch=master
 default_hub_user=ocaml
 default_opam_version=2
 default_base_remote_branch=master
+beta_repository=git://github.com/ocaml/ocaml-beta-repository.git
 
 fork_user=${FORK_USER:-$default_user}
 fork_branch=${FORK_BRANCH:-$default_branch}
 hub_user=${HUB_USER:-$default_hub_user}
 opam_version=${OPAM_VERSION:-$default_opam_version}
 base_remote_branch=${BASE_REMOTE_BRANCH:-$default_base_remote_branch}
+
+if [ "$OCAML_BETA" = "enable" ]; then
+    if [ -z "${EXTRA_REMOTES}" ]; then
+        EXTRA_REMOTES="$beta_repository"
+    else
+        EXTRA_REMOTES="${EXTRA_REMOTES} $beta_repository"
+    fi
+fi
 
 # create env file
 rm -f env.list
@@ -86,9 +95,14 @@ fi
 
 case $opam_version in
     2)
+      opam_switch_selection=
+      if [ "$OCAML_BETA" = "enable" ]; then
+          echo "RUN opam repo add --dont-select beta $beta_repository" >> Dockerfile
+          opam_switch_selection="--repo=default,beta "
+      fi
       echo "RUN opam switch ${OCAML_VERSION} ||\
-          opam switch create ocaml-base-compiler.${OCAML_VERSION} ||\
-          opam switch create ${OCAML_VERSION}" >> Dockerfile ;;
+          opam switch create ${opam_switch_selection}ocaml-base-compiler.${OCAML_VERSION} ||\
+          opam switch create ${opam_switch_selection}${OCAML_VERSION}" >> Dockerfile ;;
     *) ;;
 esac
 


### PR DESCRIPTION
It is currently very hard to simply test packages against beta/rc or other ocaml-variants (flambda, ...) with the travis-docker script. This PR fixes this issue by introducing a new environment variable `OCAML_BETA` which when equal to `enable` adds the ocaml-beta-repository to the repositories used by opam to create new switches.

This change was tested successfully in `mdx`: https://travis-ci.org/realworldocaml/mdx/builds/635266545 (PR: https://github.com/realworldocaml/mdx/pull/204)