### PR TITLE
Travis-ocaml: Add a config variable to enable ocaml-beta and allow unlisted compilers to be installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - OCAML_VERSION=4.07
   - OCAML_VERSION=4.08
   - OCAML_VERSION=4.09
+  - OCAML_VERSION=4.10.0+beta1 OCAML_BETA=enable
 os:
   - linux
   - osx


### PR DESCRIPTION
This is a second PR in the same vein than https://github.com/ocaml/ocaml-ci-scripts/pull/319 but for `.travis-ocaml.sh`

This feature would allow to test more rigorously packages with beta or release candidate versions of the compiler and would warn early if something breaks with such a version.