### PR TITLE
Fix travis-ocaml when an opam installation is already present

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -340,7 +340,7 @@ case $OPAM_INIT in
           opam repo add --dont-select beta git://github.com/ocaml/ocaml-beta-repository.git
           opam_repo_selection="--repo=default,beta"
       fi
-      opam switch create $opam_repo_selection "$OPAM_SWITCH"
+      opam switch "$OPAM_SWITCH" || opam switch create $opam_repo_selection "$OPAM_SWITCH"
       eval $(opam config env)
       ;;
 esac


### PR DESCRIPTION
Fixes an issue reported by @hhugo in https://github.com/ocaml/ocaml-ci-scripts/commit/340e8856d661f2393836d68fadccf46f20516c02#r37309533