### PR TITLE
fix appveyor install instructions

### DIFF
--- a/appveyor-install.ps1
+++ b/appveyor-install.ps1
@@ -4,7 +4,7 @@ $cyg_root="C:\cygwin64"
 $cyg_setup="setup-x86_64.exe"
 $cyg_mirror="http://cygwin.mirror.constant.com"
 $appveyor_build_folder=".\"
-$cyg_pkgs="mingw64-x86_64-gcc-core,mingw64-x86_64-headers,mingw64-x86_64-runtime,mingw64-x86_64-winpthreads"
+$cyg_pkgs=""
 
 if ( Test-Path env:fork_user ){
     $fork_user=$env:fork_user


### PR DESCRIPTION
Updating gcc is not longer necessary, because appveyor updated their images and a recent enough version of gcc is now installed by default. The current instructions don't work any longer, because the most recent version of mingw64-i686-gcc-core would also require a newer versions of mingw64-x86_64-binutils.

This hopefully fixes #325

The second commit is not intended for merge. I will remove it, once the CI is happy.