### PR TITLE
Bionic has bubblewrap in repo

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -101,7 +101,7 @@ install_opam2 () {
     case $TRAVIS_OS_NAME in
         linux)
             case $TRAVIS_DIST in
-                precise|trusty|xenial|bionic)
+                precise|trusty|xenial)
                     add_ppa ansible/bubblewrap ;;
             esac
             if [ "${INSTALL_LOCAL:=0}" = 0 ] ; then


### PR DESCRIPTION
This removes the dependency of the ansible/bubblewrap PPA which has removed bionic builds.

Currently all tests on bionic fail, because the PPA can't be installed. [Example](https://travis-ci.org/github/didier-wenzek/ocaml-kafka/jobs/665881958).