### PR TITLE
Three minor fixes

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -2,7 +2,7 @@
 # To use this, run `opam travis --help`
 
 fold_name="prepare"
-echo -en "travis_fold:start:$fold_name.ci\r"
+( set +x; echo -en "travis_fold:start:$fold_name.ci\r" ) 2>/dev/null
 default_user=ocaml
 default_branch=master
 default_hub_user=ocaml
@@ -123,5 +123,5 @@ echo docker run --env-file=env.list -v ${OS}:/repo local-build ci-opam
 
 # run ci-opam with the local repo volume mounted
 chmod -R a+w $OS
-echo -en "travis_fold:end:$fold_name.ci\r"
+( set +x; echo -en "travis_fold:end:$fold_name.ci\r" ) 2>/dev/null
 docker run --env-file=env.list -v ${OS}:/repo local-build ci-opam

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -223,6 +223,7 @@ install_on_linux () {
     make world.opt
     sudo make install
     cd ..
+    rm -rf "ocaml-$OCAML_FULL_VERSION"
     ( set +x; echo -en "travis_fold:end:build.ocaml\r" ) 2>/dev/null
   fi
 }

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -214,7 +214,7 @@ install_on_linux () {
   fi
 
   if [ "${INSTALL_LOCAL:=0}" != 0 ] ; then
-    echo -en "travis_fold:start:build.ocaml\r"
+    ( set +x; echo -en "travis_fold:start:build.ocaml\r" ) 2>/dev/null
     echo "Building a local OCaml; this may take a few minutes..."
     wget "http://caml.inria.fr/pub/distrib/ocaml-${OCAML_FULL_VERSION%.*}/ocaml-$OCAML_FULL_VERSION.tar.gz"
     tar -xzf "ocaml-$OCAML_FULL_VERSION.tar.gz"
@@ -223,7 +223,7 @@ install_on_linux () {
     make world.opt
     sudo make install
     cd ..
-    echo -en "travis_fold:end:build.ocaml\r"
+    ( set +x; echo -en "travis_fold:end:build.ocaml\r" ) 2>/dev/null
   fi
 }
 

--- a/.travis-opam.sh
+++ b/.travis-opam.sh
@@ -1,4 +1,4 @@
-echo -en "travis_fold:start:prepare.ci\r"
+( set +x; echo -en "travis_fold:start:prepare.ci\r"; ) 2>/dev/null
 # If a fork of these scripts is specified, use that GitHub user instead
 fork_user=${FORK_USER:-ocaml}
 
@@ -32,5 +32,5 @@ opam remove -a travis-opam
 
 mv ~/ci-opam ~/.opam/$(opam switch show)/bin/ci-opam
 
-echo -en "travis_fold:end:prepare.ci\r"
+( set +x; echo -en "travis_fold:end:prepare.ci\r" ) 2>/dev/null
 opam config exec -- ci-opam

--- a/src/ci_opam.ml
+++ b/src/ci_opam.ml
@@ -334,7 +334,7 @@ with_fold "Simple.depopts" (fun () ->
           ?|> "opam show %s | grep -oP 'depopts: \\K(.*)' | sed 's/ | / /g'" pkg
         in
         Some d
-      | depopts -> Some (depopts *~ " ")
+      | depopts -> echo "DEPOPTS=%s" (depopts *~ " "); Some (depopts *~ " ")
     in
     match depopts_run with
     | None   -> echo "DEPOPTS=false, skipping the optional dependency run.";


### PR DESCRIPTION
[This Travis log](https://travis-ci.org/github/dra27/opam-file-format/jobs/686603903) reveals a couple of errors in the folding in Travis. Firstly, the `prepare.ci` part is [not displayed correctly](https://travis-ci.org/github/dra27/opam-file-format/jobs/686603903#L207) and can't be opened; secondly, the `Installing.DEPOPTS` part appears to display correctly, but [can't be expanded](https://travis-ci.org/github/dra27/opam-file-format/jobs/686603903#L725). Turns out there are two issues:

- When you start a fold, there must be at least one line of text before the next fold is started (known: see https://github.com/travis-ci/travis-ci/issues/1352#issuecomment-203523502). When `DEPOPTS` is set to a value, nothing is displayed between the two folds. My solution for this is simply to display a summary of the `DEPOPTS` option (the scripts aren't picky about what's displayed for the other folds)
- `set -x` causes the fold starts to be displayed twice, which appears to cause the problems with `prepare.ci`. My solution for this is `( set +x ; echo -en … ) 2>/dev/null`. The subshell removes the need for `set -x` afterwards (especially if the user chose to run the script without `-x` in the first place) and the piping of stderr to /dev/null suppresses the `+ set +x` from bash if `set -x` was in force when the subshell was launched.
- Unrelatedly, but trivially, I found a problem with that particular build an `INSTALL_LOCAL=1`, because in this mode there's a compiler left in the project directory which dune then detects. This is a mistake, given that the compiler is installed, so I've added the appropriate `rm -rf` at the end of the build to erase that source tree.