### PR TITLE
Don't build ocaml-secondary-compiler twice for Dune-based projects

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -274,6 +274,12 @@ fi
 
 OPAM_SWITCH=${OPAM_SWITCH:-$ocaml_package.$OCAML_FULL_VERSION}
 
+PACKAGES="$OPAM_SWITCH"
+case "$OCAML_VERSION" in
+  3.12|4.00|4.01|4.02|4.03|4.04|4.05|4.06)
+    PACKAGES="$PACKAGES,ocaml-secondary-compiler";;
+esac
+
 export OPAMYES=1
 
 case $OPAM_INIT in
@@ -284,7 +290,7 @@ case $OPAM_INIT in
           opam repo add --dont-select beta git://github.com/ocaml/ocaml-beta-repository.git
           opam_repo_selection="--repo=default,beta"
       fi
-      opam switch "$OPAM_SWITCH" || opam switch create $opam_repo_selection "$OPAM_SWITCH"
+      opam switch "$OPAM_SWITCH" || opam switch create $opam_repo_selection "$OPAM_SWITCH" --packages="$PACKAGES"
       eval $(opam config env)
       ;;
 esac


### PR DESCRIPTION
ci-opam uses Dune, which will install ocaml-secondary-compiler on OCaml < 4.07. If the project itself uses Dune, it then installs ocaml-secondary-compiler again which is slow and Carbon-creating 🙂

This PR simply makes `ocaml-secondary-compiler` part of the switch base for OCaml < 4.07 (the case expresssion is copied from a previous usage to be consistent - good luck with 3.12, 4.00 and 4.01 support!)

Here's a matrix from before [showing 4.02-4.06 taking nearly twice the time of the others](https://travis-ci.org/github/dra27/opam-file-format/builds/687175920) and then here's another [with the change where the builds are rather closer](https://travis-ci.org/github/dra27/opam-file-format/builds/687337962).