### PR TITLE
Run tests on revdeps

### DIFF
--- a/src/ci_opam.ml
+++ b/src/ci_opam.ml
@@ -370,11 +370,12 @@ with_fold "Reverse.dependencies" (fun () ->
         ) [] packages in
       let installable_count = List.length packages in
       echo "%d/%d REVDEPS installable" installable_count revdep_count;
+      let install_args = if tests_run then "-t" else "" in
 
       ignore (List.fold_left (fun i dependent ->
           echo "\nInstalling %s (REVDEP %d/%d)" dependent i installable_count;
           ?|~ "opam depext -u %s" dependent;
-          ?|~ "opam install %s" dependent;
+          ?|~ "opam install %s %s" dependent install_args;
           ?|~ "opam remove %s" dependent;
           i + 1
         ) 1 packages)


### PR DESCRIPTION
There does not seem to be a way to run reverse-dependencies tests currently. We would like to do that for ppx_deriving CI (see https://github.com/ocaml-ppx/ppx_deriving/pull/227).

In this pull-request, I propose to run tests on reverse-dependencies when `TESTS=true` (the default) and `REVDEPS` is `true` or lists some reverse dependencies to test (no by default).