### PR TITLE
Add support for ARM64 + tmp fix for 4.12

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -315,7 +315,8 @@ echo OPAM_SWITCH=$OPAM_SWITCH     >> .travis-ocaml.env
 echo export ASSUME_ALWAYS_YES=YES >> .travis-ocaml.env
 
 if [ -x "$(command -v ocaml)" ]; then
-    ocaml -version
+    # "|| true" is a temp fix for OCaml 4.12: https://github.com/ocaml/ocaml/pull/9798
+    ocaml -version || true
 else
     echo "OCaml is not yet installed"
 fi

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -28,6 +28,12 @@ OCAML_BETA=${OCAML_BETA:-disable}
 
 OPAM_LATEST_RELEASE=2.0.7
 
+case $TRAVIS_CPU_ARCH in
+    amd64) OPAM_ARCH=x86_64;;
+    arm64) OPAM_ARCH=arm64;;
+    *) echo "'$TRAVIS_CPU_ARCH' architecture not currently supported"; exit 1;;
+esac
+
 case $OPAM_VERSION in
     2|2.0) OPAM_VERSION=$OPAM_LATEST_RELEASE;;
     1.*) echo "Opam version '$OPAM_VERSION' is not supported"; exit 1;;
@@ -115,13 +121,13 @@ install_opam2 () {
                 install_ocaml
             fi
             apt_install bubblewrap
-            sudo wget https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-x86_64-linux -O /usr/local/bin/opam
+            sudo wget https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$OPAM_ARCH-linux -O /usr/local/bin/opam
             sudo chmod +x /usr/local/bin/opam ;;
         osx)
             if [ "${INSTALL_LOCAL:=0}" = 0 ] ; then
                 brew install ocaml
             fi
-            sudo curl -fsSL https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-x86_64-macos -o /usr/local/bin/opam
+            sudo curl -fsSL https://github.com/ocaml/opam/releases/download/$OPAM_VERSION/opam-$OPAM_VERSION-$OPAM_ARCH-macos -o /usr/local/bin/opam
             sudo chmod +x /usr/local/bin/opam ;;
     esac
 }

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -29,7 +29,7 @@ OCAML_BETA=${OCAML_BETA:-disable}
 OPAM_LATEST_RELEASE=2.0.7
 
 case ${TRAVIS_CPU_ARCH:-amd64} in
-    amd64) OPAM_ARCH=x86_64;;
+    amd64|notset) OPAM_ARCH=x86_64;;
     arm64) OPAM_ARCH=arm64;;
     *) echo "'$TRAVIS_CPU_ARCH' architecture not currently supported"; exit 1;;
 esac

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -28,7 +28,7 @@ OCAML_BETA=${OCAML_BETA:-disable}
 
 OPAM_LATEST_RELEASE=2.0.7
 
-case $TRAVIS_CPU_ARCH in
+case ${TRAVIS_CPU_ARCH:-amd64} in
     amd64) OPAM_ARCH=x86_64;;
     arm64) OPAM_ARCH=arm64;;
     *) echo "'$TRAVIS_CPU_ARCH' architecture not currently supported"; exit 1;;

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -115,7 +115,8 @@ install_opam2 () {
         linux)
             case $TRAVIS_DIST in
                 precise|trusty|xenial)
-                    add_ppa ansible/bubblewrap ;;
+                    # Required for bubblewrap (supports arm64 & amd64)
+                    add_ppa avsm/ppa ;;
             esac
             if [ "${INSTALL_LOCAL:=0}" = 0 ] ; then
                 install_ocaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ os:
   - freebsd
   - linux
   - osx
+arch:
+  - amd64
+  - arm64


### PR DESCRIPTION
Partially fixes #316 by adding ARM64 support (the 2 other new platforms are not available as ready-to-use opam binaries so it's a little more tricky. See https://github.com/ocaml/opam/releases/tag/2.0.7)
Also temporarily fixes issues in 4.12 trunk (https://github.com/ocaml/ocaml/pull/9798)