### PR TITLE
Show brew update's output to avoid travis' 10mins timeout

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -40,7 +40,10 @@ case $OPAM_VERSION in
 esac
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
-    travis_wait 20 brew update &> /dev/null
+    brew update &> /dev/null &
+    watch -n 60 echo "brew update is still running..." &
+    wait %1
+    kill %2
     BREW_OPAM_VERSION=$(brew info opam --json=v1 | sed -e 's/.*"versions":{[^}]*"stable":"//' -e 's/".*//')
     if [ "$OPAM_VERSION" != "$BREW_OPAM_VERSION" ] ; then
         set +x

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -40,7 +40,7 @@ case $OPAM_VERSION in
 esac
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
-    brew update
+    brew update --quiet
     BREW_OPAM_VERSION=$(brew info opam --json=v1 | sed -e 's/.*"versions":{[^}]*"stable":"//' -e 's/".*//')
     if [ "$OPAM_VERSION" != "$BREW_OPAM_VERSION" ] ; then
         set +x

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -40,7 +40,7 @@ case $OPAM_VERSION in
 esac
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
-    brew update &> /dev/null
+    brew update
     BREW_OPAM_VERSION=$(brew info opam --json=v1 | sed -e 's/.*"versions":{[^}]*"stable":"//' -e 's/".*//')
     if [ "$OPAM_VERSION" != "$BREW_OPAM_VERSION" ] ; then
         set +x

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -40,6 +40,7 @@ case $OPAM_VERSION in
 esac
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
+    HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED=1
     brew update --quiet
     BREW_OPAM_VERSION=$(brew info opam --json=v1 | sed -e 's/.*"versions":{[^}]*"stable":"//' -e 's/".*//')
     if [ "$OPAM_VERSION" != "$BREW_OPAM_VERSION" ] ; then

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -41,7 +41,7 @@ esac
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
     brew update &> /dev/null &
-    watch -n 60 echo "brew update is still running..." &
+    while sleep 60; do echo "brew update is still running..."; done &
     wait %1
     kill %2
     BREW_OPAM_VERSION=$(brew info opam --json=v1 | sed -e 's/.*"versions":{[^}]*"stable":"//' -e 's/".*//')

--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -40,8 +40,7 @@ case $OPAM_VERSION in
 esac
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
-    HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED=1
-    brew update --quiet
+    travis_wait 20 brew update &> /dev/null
     BREW_OPAM_VERSION=$(brew info opam --json=v1 | sed -e 's/.*"versions":{[^}]*"stable":"//' -e 's/".*//')
     if [ "$OPAM_VERSION" != "$BREW_OPAM_VERSION" ] ; then
         set +x


### PR DESCRIPTION
The MacOS check in opam-repository fails way too often during `brew update` as it apparently takes more than 10 minutes and does not show any output due to the `&> /dev/null`.

Hopefully this change is fine and does not produce an unreasonable amount of log