### PR TITLE
Fix syntax error on docker travis build?

### DIFF
--- a/.travis-docker.sh
+++ b/.travis-docker.sh
@@ -55,7 +55,7 @@ if [ -n "$BASE_REMOTE" ]; then
     echo "RUN opam repo remove --all default && opam repo add --all-switches default ${BASE_REMOTE}#${base_remote_branch}" >> Dockerfile
 else
     echo RUN git checkout master >> Dockerfile
-    echo RUN git pull -q origin master >> Dockerfile ;;
+    echo RUN git pull -q origin master >> Dockerfile
 fi
 echo RUN opam update --verbose >> Dockerfile
 


### PR DESCRIPTION
I'm seeing the following error on travis-ci which I think should be fixed by removing `;;`?

```bash
+from=ocaml/opam:debian-stable
244+echo FROM ocaml/opam:debian-stable
245+echo WORKDIR /home/opam/opam-repository
246./.travis-docker.sh: line 58: syntax error near unexpected token `;;'
247The command "bash -ex ./.travis-docker.sh" exited with 2.
248
249
250Done. Your build exited with 1.
```