### PR TITLE
Use HTTPS mirror

### DIFF
--- a/appveyor-install.ps1
+++ b/appveyor-install.ps1
@@ -2,7 +2,7 @@ $fork_user="ocaml"
 $fork_branch="master"
 $cyg_root="C:\cygwin64"
 $cyg_setup="setup-x86_64.exe"
-$cyg_mirror="http://cygwin.mirror.constant.com"
+$cyg_mirror="https://cygwin.mirror.constant.com"
 $appveyor_build_folder=".\"
 $cyg_pkgs=""
 


### PR DESCRIPTION
There is some weirdness with file checks going on on appveyor and using HTTPS will prevent potential proxies with meddling with the data.

Attempts to solve problems in builds like these: https://ci.appveyor.com/project/ygrek/ocaml-extlib/builds/44404178