### PR TITLE
Fix typo in ocaml version number

### DIFF
--- a/.travis-ocaml.sh
+++ b/.travis-ocaml.sh
@@ -201,7 +201,7 @@ install_on_linux () {
     4.11) OCAML_FULL_VERSION=4.11.2; install_opam2 ;;
     4.12) OCAML_FULL_VERSION=4.12.1; install_opam2 ;;
     4.13) OCAML_FULL_VERSION=4.13.1; install_opam2 ;;
-    4.13) OCAML_FULL_VERSION=4.14.0; install_opam2 ;;
+    4.14) OCAML_FULL_VERSION=4.14.0; install_opam2 ;;
     5.0) OCAML_FULL_VERSION=5.0.0+trunk; OCAML_BETA=enable; install_opam2 ;;
     *)
         if [ "$OCAML_BETA" != "enable" ]; then


### PR DESCRIPTION
Small typo in a `case` for selecting an ocaml version